### PR TITLE
added \header command for table headers and default values [XX] for tables' arguments.

### DIFF
--- a/lib/dnditemtable.sty
+++ b/lib/dnditemtable.sty
@@ -1,9 +1,9 @@
 % Table Environment
-\newenvironment{dnditemtable}{
+\newenvironment{dnditemtable}[1][XX]{
 	\par\vspace*{8pt}
     \noindent
     \fontfamily{lmss}\selectfont %Select font
     \rowcolors{1}{bgtan}{itemtablepink} % Alternate colors
-    \tabularx{\linewidth}{XX}
+    \tabularx{\linewidth}{#1}
 	}
-	{\vspace{8pt plus 1pt}\noindent\endtabularx}
+	{\endtabularx\vspace{8pt plus 1pt}\noindent} 

--- a/lib/dnditemtable.sty
+++ b/lib/dnditemtable.sty
@@ -1,9 +1,9 @@
 % Table Environment
 \newenvironment{dnditemtable}[1][XX]{
 	\par\vspace*{8pt}
-    \noindent
-    \fontfamily{lmss}\selectfont %Select font
-    \rowcolors{1}{bgtan}{itemtablepink} % Alternate colors
-    \tabularx{\linewidth}{#1}
+	\noindent
+	\fontfamily{lmss}\selectfont %Select font
+	\rowcolors{1}{bgtan}{itemtablepink} % Alternate colors
+	\tabularx{\linewidth}{#1}
 	}
 	{\endtabularx\vspace{8pt plus 1pt}\noindent} 

--- a/lib/dndtable.sty
+++ b/lib/dndtable.sty
@@ -1,9 +1,16 @@
+% Table Header
+\newcommand{\header}[1]{{
+    \par\vspace*{8pt}
+    \noindent
+    \sffamily\bfseries\scshape
+    #1}}
+
 % Table Environment
-\newenvironment{dndtable}[1]{
+\newenvironment{dndtable}[1][XX]{
 	\par\vspace*{8pt}
-	\noindent
-	\fontfamily{lmss}\selectfont %Select font
-	\rowcolors{1}{bgtan}{commentgreen} % Alternate colors
-	\tabularx{\linewidth}{#1}
+    \noindent
+    \fontfamily{lmss}\selectfont %Select font
+    \rowcolors{1}{bgtan}{commentgreen} % Alternate colors
+    \tabularx{\linewidth}{#1}
 	}
-	{\vspace{8pt plus 1pt}\noindent\endtabularx} 
+	{\endtabularx\vspace{8pt plus 1pt}\noindent} 

--- a/lib/dndtable.sty
+++ b/lib/dndtable.sty
@@ -1,16 +1,16 @@
 % Table Header
 \newcommand{\header}[1]{{
-    \par\vspace*{8pt}
-    \noindent
-    \sffamily\bfseries\scshape
-    #1}}
+	\par\vspace*{8pt}
+	\noindent
+	\sffamily\bfseries\scshape
+	#1}}
 
 % Table Environment
 \newenvironment{dndtable}[1][XX]{
 	\par\vspace*{8pt}
-    \noindent
-    \fontfamily{lmss}\selectfont %Select font
-    \rowcolors{1}{bgtan}{commentgreen} % Alternate colors
-    \tabularx{\linewidth}{#1}
+	\noindent
+	\fontfamily{lmss}\selectfont %Select font
+	\rowcolors{1}{bgtan}{commentgreen} % Alternate colors
+	\tabularx{\linewidth}{#1}
 	}
 	{\endtabularx\vspace{8pt plus 1pt}\noindent} 


### PR DESCRIPTION
Header command emulates D&D style of table headers.

Usage:
```tex
\header{DND Table}
\begin{dndtable}
	\textbf{Title 1} & \textbf{Title 2} \\
	3 & 4 \\
	5 & 6
\end{dndtable}
```