### PR TITLE
added centered column type for the dndtable

### DIFF
--- a/lib/dndtable.sty
+++ b/lib/dndtable.sty
@@ -5,6 +5,9 @@
 	\sffamily\bfseries\scshape
 	#1}}
 
+% Centered Column
+\newcolumntype{Y}{>{\centering\arraybackslash}X}
+
 % Table Environment
 \newenvironment{dndtable}[1][XX]{
 	\par\vspace*{8pt}


### PR DESCRIPTION
Center-aligned stretchable table columns are used in some official D&D modules.

Usage:
```
\begin{dndtable}[XYc]
	Stretchable left-aligned & Stretchable center-aligned & Fixed \\
\end{dndtable}
```