### PR TITLE
Exclude *.fdb_latexmk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.blg
 *.bbl
 *.synctex.gz
+*.fdb_latexmk


### PR DESCRIPTION
*.fdb_latexmk is used by latexmk, a tool that automates LaTeX builds.