### PR TITLE
Fix paragraph alignment and spacing

### DIFF
--- a/dnd.sty
+++ b/dnd.sty
@@ -21,6 +21,7 @@
 \RequirePackage{fancyhdr} 			  % Adaptation of the footers
 \RequirePackage[most]{tcolorbox}  % used for some boxes
 \RequirePackage{enumitem}
+\RequirePackage{ragged2e}
 
 % Load other modules of this package
 \usepackage{lib/dndmonster}
@@ -46,6 +47,10 @@
 \DeclareOption{bg-print}{\toggletrue{bool-bg-print}}
 \DeclareOption{bg-full}{\togglefalse{bool-bg-print}}
 
+% Toggle justification (official books are flush left).
+\newtoggle{justified}
+\DeclareOption{justified}{\toggletrue{justified}}
+
 % Default Settings
 \ExecuteOptions{bg-letter, bg-full}
 \ProcessOptions\relax
@@ -65,6 +70,11 @@
       \RequirePackage[letter,full]{lib/dndbackgroundimg}
 		}
 	}
+}
+
+\nottoggle{justified}{
+  \setlength{\RaggedRightParindent}{1em}
+  \RaggedRight
 }
 
 %

--- a/dnd.sty
+++ b/dnd.sty
@@ -81,6 +81,9 @@
 % Style Parameters
 %
 
+% Disable space between paragraphs.
+\setlength{\parskip}{0pt}
+
 % Font environment
 \newenvironment{lmss}{\fontfamily{lmss}\selectfont}{}
 

--- a/example.tex
+++ b/example.tex
@@ -3,7 +3,7 @@
 %
 % Note that the article class does not have chapters.
 \documentclass[10pt,twoside,twocolumn,openany]{book}
-\usepackage[bg-letter]{dnd} % Options: bg-a4, bg-letter, bg-full, bg-print, bg-none.
+\usepackage[bg-letter]{dnd} % Options: bg-a4, bg-letter, bg-full, bg-print, bg-none, justified
 \usepackage[english]{babel}
 \usepackage[utf8]{inputenc}
 


### PR DESCRIPTION
The books are flush left, but LaTeX defaults to justified.

This changeset:

* Makes flush left the default alignment. `ragged2e` enables smart hypenation and lets us indent paragraphs.
* Adds a `justified` package option to restore the current behaviour.
* Disables paragraph spacing.

This is technically a breaking change, but it is required to better match the official books.

I would re-render the example PDF, but there will be a merge conflict with other branches that re-render it. Maybe we could host the PDF outside the repo.