### PR TITLE
add quotebox color and clean up themed tcolorbox

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -38,8 +38,10 @@
 
 \lipsum[1-2]
 
-\begin{commentbox}{Neat Green Box!}
-	\lipsum[1-2]
+\begin{commentbox}{This Is a Comment Box!}
+  A commentbox is a box for minimal highlighting of text. It lacks the ornamentation of paperbox, but it can handle being broken over a column.
+  
+  \lipsum[2]
 \end{commentbox}
 
 \subtitlesection{Weapon, +1, +2, or +3}

--- a/example.tex
+++ b/example.tex
@@ -123,7 +123,7 @@
 
 \section{Colors}
 
-This package provides several global color variables to style \verb=commentbox=, \verb=quotebox=, and \verb=dndtable= environments.
+This package provides several global color variables to style \verb=commentbox=, \verb=quotebox=, \verb=paperbox=, and \verb=dndtable= environments.
 
 \begin{dndtable}[lX]
   \textbf{Color}         & \textbf{Description} \\
@@ -152,9 +152,9 @@ See Table~\ref{tab:colors} for a list of accent colors that match the core books
 \end{table*}
 
 \begin{itemize}
-  \item Use \verb=\setthemecolor[<color>]= to set \verb=themecolor=, \verb=commentcolor=, \verb=paperboxcolor=, \verb=quoteboxcolor=, and \verb=tablecolor= to a specific color.
-  \item Calling \verb=\setthemecolor= without an argument sets all colors to the current \verb=themecolor=.
-  \item \verb=commentbox=, \verb=dndtable=, \verb=paperbox=, and \verb=quoteboxcolor= accept an optional color argument to set the color for a single instance.
+  \item Use \verb=\setthemecolor[<color>]= to set \verb=themecolor=, \verb=commentcolor=, \verb=paperboxcolor=, and \verb=tablecolor= to a specific color.
+  \item Calling \verb=\setthemecolor= without an argument sets those colors to the current \verb=themecolor=.
+  \item \verb=commentbox=, \verb=dndtable=, \verb=paperbox=, and \verb=quoteboxcolor= also accept an optional color argument to set the color for a single instance.
 \end{itemize}
 
 \subsection{Examples}

--- a/example.tex
+++ b/example.tex
@@ -129,11 +129,11 @@ This package provides several global color variables to style \verb=commentbox=,
   \textbf{Color}         & \textbf{Description} \\
   \verb=commentboxcolor= & Controls \verb=commentbox= background. \\
   \verb=paperboxcolor=   & Controls \verb=paperbox= background. \\
+  \verb=quoteboxcolor=   & Controls \verb=quotebox= background. \\
   \verb=tablecolor=      & Controls background of even \verb=dndtable= rows. \\
-  \verb=trimcolor=       & Use this to control the color of custom elements. \\
 \end{dndtable}
 
-See Table \ref{tab:colors} for a list of accent colors that match the core books.
+See Table~\ref{tab:colors} for a list of accent colors that match the core books.
 
 \begin{table*}
   \begin{dndtable}[XX]
@@ -147,14 +147,14 @@ See Table \ref{tab:colors} for a list of accent colors that match the core books
     \verb=DmgSlateGray= (\verb=DmgSlateGrey=) & Blue-gray used in PHB Part 3 \\
     \verb=DmgLilac=                           & Purple-gray used in DMG appendix \\
   \end{dndtable}
-  \caption{Colors supported by this package}
+  \caption{Colors supported by this package}%
   \label{tab:colors}
 \end{table*}
 
 \begin{itemize}
-  \item Use \verb=\setthemecolor[<color>]= to set \verb=commentcolor=, \verb=paperboxcolor=, \verb=themecolor=, and \verb=trimcolor= to a specific color.
+  \item Use \verb=\setthemecolor[<color>]= to set \verb=themecolor=, \verb=commentcolor=, \verb=paperboxcolor=, \verb=quoteboxcolor=, and \verb=tablecolor= to a specific color.
   \item Calling \verb=\setthemecolor= without an argument sets all colors to the current \verb=themecolor=.
-  \item \verb=commentbox=, \verb=dndtable=, and \verb=paperbox= all accept an optional color argument to set the color for a single instance.
+  \item \verb=commentbox=, \verb=dndtable=, \verb=paperbox=, and \verb=quoteboxcolor= accept an optional color argument to set the color for a single instance.
 \end{itemize}
 
 \subsection{Examples}

--- a/lib/dndcolors.sty
+++ b/lib/dndcolors.sty
@@ -23,34 +23,26 @@
 % Trim aliases
 \colorlet{DmgSlateGrey}{DmgSlateGray}
 
-% Stat blocks
-\definecolor{statblockribbon}{HTML}{E69A28} % top/bottom borders (gold)
+% The color used in \setthemecolor when a new color is not set
+\colorlet{themecolor}{PhbLightGreen}    % Set the default theme to Part 1 of the PHB.
+
+% Element colors that change when \setthemecolor is used
+\colorlet{commentboxcolor}{themecolor}  % commentbox background
+\colorlet{paperboxcolor}{themecolor}    % paperbox background
+\colorlet{tablecolor}{themecolor}       % table even row background
+
+% Element colors that do not respond to \setthemecolor
+\colorlet{quoteboxcolor}{bgtan}             % quotebox background
+\definecolor{statblockribbon}{HTML}{E69A28} % stat block top/bottom borders (gold)
 \definecolor{statblockbg}{HTML}{FDF1DC}     % stat block background (tan)
 
-% Global colour variables
-%
-%   commentboxcolor   commentbox background
-%   paperboxcolor     paperbox background
-%   trimcolor         colour of custom elements added by user
-%   tablecolor        table even row background
-%   themecolor        changing this with \setthemecolor sets all colours
-
-% Set the default theme to Part 1 of the PHB.
-\colorlet{themecolor}{PhbLightGreen}
-
-% Add element-specific colours.
-\colorlet{commentboxcolor}{themecolor}
-\colorlet{paperboxcolor}{themecolor}
-\colorlet{tablecolor}{themecolor}
-\colorlet{trimcolor}{themecolor}
-
-% Offer commands to set all accent colours.
+% Sets the themecolor and colors for all themed elements
+% If called without the optional color, resets the color of all themed elements to the current themecolor
 \newcommand{\setthemecolor}[1][themecolor]{%
+  \colorlet{themecolor}{#1}
   \colorlet{commentboxcolor}{#1}
   \colorlet{paperboxcolor}{#1}
   \colorlet{tablecolor}{#1}
-  \colorlet{themecolor}{#1}
-  \colorlet{trimcolor}{#1}
 }
 
 % Backwards-compatible aliases and colours

--- a/lib/dndcolors.sty
+++ b/lib/dndcolors.sty
@@ -11,7 +11,7 @@
 \definecolor{rulered}{HTML}{9C2B1B}		% triangular rule in statsblock
 
 % Trim (affects tables and paperboxes)
-\definecolor{PhbLightGreen}{HTML}{E0E5C1} % PHB Part 1
+\definecolor{PhbLightGreen}{HTML}{DBE5C2} % PHB Part 1
 \definecolor{PhbLightCyan}{HTML}{B5CEB8}  % PHB Part 2
 \definecolor{PhbMauve}{HTML}{DCCCC5}      % PHB Part 3
 \definecolor{PhbTan}{HTML}{E5D5AC}        % PHB appendix

--- a/lib/dndcomment.sty
+++ b/lib/dndcomment.sty
@@ -1,5 +1,5 @@
-%Usage \begin{commentbox}[options]{title}
-\newtcolorbox{commentbox}[2][]{%
+%Usage \begin{commentbox}[options]{title}[color]
+\DeclareTColorBox{commentbox}{O{} m O{commentboxcolor}}{%
 	before upper={\nottoggle{justified}{\RaggedRight}},
 	frame hidden,
 	boxrule=0pt,
@@ -15,8 +15,8 @@
 	fontupper=\fontfamily{lmss}\selectfont,
 	title=#2,
 	parbox=false,
-	colback=commentboxcolor,
-	colbacktitle=commentboxcolor,
+	colback=#3,
+	colbacktitle=#3,
 	after={\vspace{5pt plus 1pt}\noindent},
 	#1
 }

--- a/lib/dndcomment.sty
+++ b/lib/dndcomment.sty
@@ -1,5 +1,5 @@
-% Green comment box definition
-\DeclareTColorBox{commentbox}{O{} m O{commentboxcolor}}{
+%Usage \begin{commentbox}[options]{title}
+\newtcolorbox{commentbox}[2][]{%
 	before upper={\nottoggle{justified}{\RaggedRight}},
 	frame hidden,
 	boxrule=0pt,
@@ -15,9 +15,8 @@
 	fontupper=\fontfamily{lmss}\selectfont,
 	title=#2,
 	parbox=false,
-	colback=#3,
-	colframe=#3,
-	colbacktitle=#3,
+	colback=commentboxcolor,
+	colbacktitle=commentboxcolor,
 	after={\vspace{5pt plus 1pt}\noindent},
 	#1
 }

--- a/lib/dndpaperbox.sty
+++ b/lib/dndpaperbox.sty
@@ -1,5 +1,5 @@
-%Usage \begin{paperbox}[options]{title}[color]
-\DeclareTColorBox{paperbox}{O{} m O{paperboxcolor}}{
+%Usage \begin{paperbox}[options]{title}
+\newtcolorbox{paperbox}[2][]{%
 	before upper={\nottoggle{justified}{\RaggedRight}},
 	frame hidden,
 	boxrule=0pt,
@@ -16,15 +16,14 @@
 	parbox=false,
 	borderline north={1pt}{-0.5pt}{black},
 	borderline south={1pt}{-0.5pt}{black},
-	colback=#3,
-	colframe=#3,
-	colbacktitle=#3,
+	colback=paperboxcolor,
+	colbacktitle=paperboxcolor,
 	fuzzy shadow={0mm}{-3.5pt}{-0.5pt}{0.4mm}{black!60!white},
 	overlay={%
-		\fill [fill=black] (frame.south west) -- ++(7pt,0) -- ++(0,-5pt) -- cycle;
-		\fill [fill=black] (frame.north west) -- ++(7pt,0) -- ++(0,5pt) -- cycle;
-		\fill [fill=black] (frame.north east) -- ++(-7pt,0) -- ++(0,5pt) -- cycle;
-		\fill [fill=black] (frame.south east) -- ++(-7pt,0) -- ++(0,-5pt) -- cycle;
+		\fill[black] (frame.south west) -- ++ (7pt,0) -- ++ (0,-5pt) -- cycle;
+		\fill[black] (frame.north west) -- ++ (7pt,0) -- ++ (0,5pt) -- cycle;
+		\fill[black] (frame.north east) -- ++ (-7pt,0) -- ++ (0,5pt) -- cycle;
+		\fill[black] (frame.south east) -- ++ (-7pt,0) -- ++ (0,-5pt) -- cycle;
 		},
 	after={\vspace{10pt plus 1pt}\noindent},
 	#1

--- a/lib/dndpaperbox.sty
+++ b/lib/dndpaperbox.sty
@@ -1,5 +1,5 @@
-%Usage \begin{paperbox}[options]{title}
-\newtcolorbox{paperbox}[2][]{%
+%Usage \begin{paperbox}[options]{title}[color]
+\DeclareTColorBox{paperbox}{O{} m O{paperboxcolor}}{%
 	before upper={\nottoggle{justified}{\RaggedRight}},
 	frame hidden,
 	boxrule=0pt,
@@ -16,8 +16,8 @@
 	parbox=false,
 	borderline north={1pt}{-0.5pt}{black},
 	borderline south={1pt}{-0.5pt}{black},
-	colback=paperboxcolor,
-	colbacktitle=paperboxcolor,
+	colback=#3,
+	colbacktitle=#3,
 	fuzzy shadow={0mm}{-3.5pt}{-0.5pt}{0.4mm}{black!60!white},
 	overlay={%
 		\fill[black] (frame.south west) -- ++ (7pt,0) -- ++ (0,-5pt) -- cycle;

--- a/lib/dndquote.sty
+++ b/lib/dndquote.sty
@@ -1,5 +1,5 @@
-%Usage \begin{quotebox}[options]
-\newtcolorbox{quotebox}[1][]{%
+%Usage \begin{quotebox}[options][color]
+\DeclareTColorBox{quotebox}{O{} O{quoteboxcolor}}{%
     before upper={\nottoggle{justified}{\RaggedRight}},
 	enhanced jigsaw,
 	frame hidden,
@@ -10,7 +10,7 @@
 	boxsep=0.25ex,
 	left=8pt,
 	right=8pt,
-	colback=quoteboxcolor,
+	colback=#2,
 	arc=0mm,
 	parbox=false,
 	borderline west={1pt}{-0.5pt}{titlered},

--- a/lib/dndquote.sty
+++ b/lib/dndquote.sty
@@ -1,3 +1,4 @@
+%Usage \begin{quotebox}[options]
 \newtcolorbox{quotebox}[1][]{%
     before upper={\nottoggle{justified}{\RaggedRight}},
 	enhanced jigsaw,
@@ -9,16 +10,15 @@
 	boxsep=0.25ex,
 	left=8pt,
 	right=8pt,
-	colback=bgtan,
-	colframe=bgtan,
+	colback=quoteboxcolor,
 	arc=0mm,
 	parbox=false,
 	borderline west={1pt}{-0.5pt}{titlered},
 	borderline east={1pt}{-0.5pt}{titlered},
 	fontupper = \fontfamily{lmss}\selectfont,
 	overlay={%
-		\foreach \n in {north east,north west,south east,south west}
-		{\draw [titlered, fill=titlered] (frame.\n) circle (2pt); }; },
+		\foreach\n in {north east,north west,south east,south west}
+		{\draw[titlered, fill=titlered] (frame.\n) circle (2pt); }; },
 	after={\vspace{7.5pt plus 1pt}\noindent},
 	#1
 }


### PR DESCRIPTION
Add quoteboxcolor. Removed trimcolor as I realized there really was not
any reason for a user to not use themecolor instead. Removed optional
color from paperbox and commentbox as the few times a user might want to
change the color of a single commentbox or paperbox can set the
tcolorbox relevant options.