### PR TITLE
Separate fancyhdr and reduce warnings

### DIFF
--- a/dnd.sty
+++ b/dnd.sty
@@ -16,7 +16,6 @@
 \RequirePackage{tabularx}
 \RequirePackage{tikz}
 \RequirePackage{keycommand}
-\RequirePackage{fancyhdr} 			  % Adaptation of the footers
 \RequirePackage[most]{tcolorbox}  % used for some boxes
 \RequirePackage{enumitem}
 \RequirePackage{microtype}        % Improve ragged2e hyphenation and overfull boxes
@@ -24,15 +23,16 @@
 \RequirePackage{xparse}
 
 % Load other modules of this package
-\usepackage{lib/dndcolors}
-\usepackage{lib/dndmonster}
-\usepackage{lib/dndsections}
-\usepackage{lib/dndcomment}
-\usepackage{lib/dndtable}
-\usepackage{lib/dndquote}
-\usepackage{lib/dndpaperbox}
-\usepackage{lib/dndstrings}   % Load document strings
-\usepackage{lib/dndspell}
+\RequirePackage{lib/dndcolors}    % color definitions
+\RequirePackage{lib/dndcomment}   % \commentbox definition
+\RequirePackage{lib/dndheader}    % fancy headers and footers
+\RequirePackage{lib/dndmonster}   % \monsterbox definition
+\RequirePackage{lib/dndpaperbox}  % \paperbox definition
+\RequirePackage{lib/dndquote}     % \quotebox definition
+\RequirePackage{lib/dndsections}  % section styling
+\RequirePackage{lib/dndspell}     % \spell definition
+\RequirePackage{lib/dndstrings}   % Load document strings
+\RequirePackage{lib/dndtable}     % \dndtable definition
 
 %
 % Options
@@ -100,34 +100,6 @@
 \setlist{leftmargin=1em}
 \setitemize{noitemsep,topsep=0.5ex}
 \renewcommand{\labelitemi}{\raisebox{0.25ex}{\tiny{$\bullet$}}}
-
-% Setup for custom footer
-\pagestyle{fancy}
-
-\footskip = 48pt %push the footer down so it fits with the decal from the bg-img
-\fancyhfoffset[LE]{28pt} % push the footer left on even pages so it fits the decal
-\fancyhfoffset[RO]{30pt} % push the footer right on odd pages so it fits the decalbg-img
-\renewcommand{\headrulewidth}{0.0pt} %no rule for header
-\renewcommand{\footrulewidth}{0.0pt} %no rule for footer
-
-\fancyhead{} % clear all header fields
-\fancyfoot{} % clear all footer fields
-
-\fancyfoot[LE]{
-	\textcolor{pagegold}{\thepage}
-	\hspace*{0.9cm}
-	\raisebox{12pt}{\textsc{\textcolor{pagegold}{\nouppercase\leftmark}}}
-	}
-
-\fancyfoot[RO]{
-	\raisebox{12pt}{\textsc{\textcolor{pagegold}{\nouppercase\leftmark}}}
-	\hspace*{1cm}
-	\textcolor{pagegold}{\thepage}
-	}
-
-\renewcommand{\chaptermark}[1]{\markboth{#1}{}} % Don not write word "chapter"
-
-\fancypagestyle{plain}{}
 
 % Fancy DnD 5e-style hline
 \renewcommand{\hline}{

--- a/dnd.sty
+++ b/dnd.sty
@@ -8,7 +8,14 @@
 %
 % Prerequisite Packages
 %
-\RequirePackage[cm]{fullpage}     % Small margins
+% Set a different geometry with \newgeometry
+\usepackage[
+  bindingoffset=.5cm,
+  hmargin=1.75cm,
+  top=.5in,
+  bottom=.875in,
+  footskip=.6in,
+]{geometry}
 \RequirePackage{bookman}          % Closest built-in font I could find
 \RequirePackage[T1]{fontenc}
 \RequirePackage[table]{xcolor}

--- a/lib/dndbackgroundimg.sty
+++ b/lib/dndbackgroundimg.sty
@@ -1,5 +1,4 @@
-\ProvidesPackage{lib/dndbackgroundimg}[2016/03/13]
-\usepackage[pages=all]{background} %background images with different backgrounds for even and odd pages
+\RequirePackage[pages=all]{background} %background images with different backgrounds for even and odd pages
 
 \newtoggle{bool-a4}
 \newtoggle{bool-print}
@@ -29,7 +28,6 @@
 		\newcommand{\evenbackgroundimg}{img/bg-letter-even.jpg}
 		}
 	}
-
 
 \backgroundsetup{
 	scale=1,

--- a/lib/dndcolors.sty
+++ b/lib/dndcolors.sty
@@ -1,5 +1,5 @@
 % Define colors, sampled from the books.
-\usepackage{color}
+\RequirePackage{color}
 
 % Page
 \definecolor{bgtan}{HTML}{F7F2E5}		  % background and quotebox

--- a/lib/dndheader.sty
+++ b/lib/dndheader.sty
@@ -1,0 +1,28 @@
+\RequirePackage{fancyhdr} 			  % Adaptation of the footers
+
+% Setup for custom footer
+\pagestyle{fancy}
+
+\fancyhfoffset[LE]{28pt} % push the footer left on even pages so it fits the decal
+\fancyhfoffset[RO]{30pt} % push the footer right on odd pages so it fits the decalbg-img
+\renewcommand{\headrulewidth}{0.0pt} %no rule for header
+\renewcommand{\footrulewidth}{0.0pt} %no rule for footer
+
+\fancyhead{} % clear all header fields
+\fancyfoot{} % clear all footer fields
+
+\fancyfoot[LE]{
+	\textcolor{pagegold}{\thepage}
+	\hspace*{0.9cm}
+	\raisebox{12pt}{\textsc{\textcolor{pagegold}{\nouppercase\leftmark}}}
+	}
+
+\fancyfoot[RO]{
+	\raisebox{12pt}{\textsc{\textcolor{pagegold}{\nouppercase\leftmark}}}
+	\hspace*{1cm}
+	\textcolor{pagegold}{\thepage}
+	}
+
+\renewcommand{\chaptermark}[1]{\markboth{#1}{}} % Do not write word "chapter"
+
+\fancypagestyle{plain}{}

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -1,6 +1,6 @@
 % Monster environment sty file
-\usepackage{fp}
-\usepackage{xstring}
+\RequirePackage{fp}
+\RequirePackage{xstring}
 
 % Macro to print stats with autocomputed modifier
 % e.g. \stat{12} prints "12 (+1)"

--- a/lib/dndsections.sty
+++ b/lib/dndsections.sty
@@ -1,5 +1,5 @@
-\RequirePackage[toc]{multitoc}
 \RequirePackage[titles]{tocloft}
+\RequirePackage[toc]{multitoc}
 \RequirePackage{titlesec}	% Used to adjust (sub)section formatting
 
 %Remove Numbering (If you want Numbering set secnumdepth to the appropriate depth)


### PR DESCRIPTION
Separate fancyhdr code into another file.
Reduce ChkTeX warnings.
Use \RequirePackage instead of \usepackage.

Integrated part of #69 to keep the footer lining up correctly.