### PR TITLE
Use key-value package options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-* None
+* Added `bg` package option with `full`, `print`, and `none` as possible values.
 
 ### Changed
 
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Deprecated
 
-* None
+* Deprecated `bg-full`, `bg-none`, and `bg-print` package options.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,17 @@ Load the template in your preamble:
 
 ### Package options
 
-| Option      | Description                               | Default |
-|-------------|-------------------------------------------|:-------:|
-| `bg-full`   | Loads both background and footer images   |    ✓    |
-| `bg-none`   | Removes both background and footer images |         |
-| `bg-print`  | Loads only the footer image               |         |
-| `justified` | Justifies column copy                     |         |
+#### `bg`
+
+Declare how to load background and footer images. This is a key-value option with the following possible values:
+
+* `full`: Load both background and footer images. (**default**)
+* `none`: Removes both background and footer images.
+* `print`: Loads only the footer images.
+
+#### `justified`
+
+Justify column copy.
 
 ## Dependencies
 

--- a/dnd.sty
+++ b/dnd.sty
@@ -25,6 +25,7 @@
 \RequirePackage{enumitem}
 \RequirePackage{microtype}        % Improve ragged2e hyphenation and overfull boxes
 \RequirePackage{ragged2e}
+\RequirePackage{xkeyval}
 \RequirePackage{xparse}
 
 
@@ -53,19 +54,19 @@
 % 'bg-letter-img','bg-letter-print' and 'bg-none' options
 \newtoggle{bool-bg}
 \newtoggle{bool-footer-scroll}
-\DeclareOption{bg-none} {\togglefalse{bool-bg}\togglefalse{bool-footer-scroll}}
-\DeclareOption{bg-print}{\togglefalse{bool-bg}\toggletrue{bool-footer-scroll}}
-\DeclareOption{bg-full} {\toggletrue{bool-bg}\toggletrue{bool-footer-scroll}}
-\DeclareOption{bg-a4}{\dnd@deprecate{bg-a4}{0.7}[Remove call to this package option.]}
-\DeclareOption{bg-letter}{\dnd@deprecate{bg-letter}{0.7}[Remove call to this package option.]}
+\DeclareOptionX{bg-none} {\togglefalse{bool-bg}\togglefalse{bool-footer-scroll}}
+\DeclareOptionX{bg-print}{\togglefalse{bool-bg}\toggletrue{bool-footer-scroll}}
+\DeclareOptionX{bg-full} {\toggletrue{bool-bg}\toggletrue{bool-footer-scroll}}
+\DeclareOptionX{bg-a4}{\dnd@deprecate{bg-a4}{0.7}[Remove call to this package option.]}
+\DeclareOptionX{bg-letter}{\dnd@deprecate{bg-letter}{0.7}[Remove call to this package option.]}
 
 % Toggle justification (official books are flush left).
 \newtoggle{justified}
-\DeclareOption{justified}{\toggletrue{justified}}
+\DeclareOptionX{justified}{\toggletrue{justified}}
 
 % Default Settings
-\ExecuteOptions{bg-full}
-\ProcessOptions\relax
+\ExecuteOptionsX{bg-full}
+\ProcessOptionsX\relax
 
 % Set paragraph and line spacing
 \linespread{1.1}%

--- a/dnd.sty
+++ b/dnd.sty
@@ -51,12 +51,46 @@
 % Options
 %
 
-% 'bg-letter-img','bg-letter-print' and 'bg-none' options
 \newtoggle{bool-bg}
 \newtoggle{bool-footer-scroll}
-\DeclareOptionX{bg-none} {\togglefalse{bool-bg}\togglefalse{bool-footer-scroll}}
-\DeclareOptionX{bg-print}{\togglefalse{bool-bg}\toggletrue{bool-footer-scroll}}
-\DeclareOptionX{bg-full} {\toggletrue{bool-bg}\toggletrue{bool-footer-scroll}}
+\DeclareOptionX{bg}[full]{%
+  % This macro call looks complicated, but simply sets up a case environment
+  % to process choices. Refer to the xkeyval documentation for details.
+  \XKV@cc*+[\val\index]{#1}{full,none,print}{%
+    \ifcase\index\relax
+    % full
+    \toggletrue{bool-bg}
+    \toggletrue{bool-footer-scroll}
+    \or
+    % none
+    \togglefalse{bool-bg}
+    \togglefalse{bool-footer-scroll}
+    \or
+    % print
+    \togglefalse{bool-bg}
+    \toggletrue{bool-footer-scroll}
+    \fi
+  }{%
+    \PackageWarning{dnd}{\val\ is not a valid choice for bg and was ignored}
+  }
+}
+
+% Legacy bg option variants.
+\DeclareOptionX{bg-full}{%
+  \dnd@deprecate{bg-full}{0.7}[Use bg=full instead.]
+  \toggletrue{bool-bg}
+  \toggletrue{bool-footer-scroll}
+}
+\DeclareOptionX{bg-none}{%
+  \dnd@deprecate{bg-none}{0.7}[Use bg=none instead.]
+  \togglefalse{bool-bg}
+  \togglefalse{bool-footer-scroll}
+}
+\DeclareOptionX{bg-print}{%
+  \dnd@deprecate{bg-print}{0.7}[Use bg=print instead.]
+  \togglefalse{bool-bg}
+  \toggletrue{bool-footer-scroll}
+}
 \DeclareOptionX{bg-a4}{\dnd@deprecate{bg-a4}{0.7}[Remove call to this package option.]}
 \DeclareOptionX{bg-letter}{\dnd@deprecate{bg-letter}{0.7}[Remove call to this package option.]}
 
@@ -65,7 +99,7 @@
 \DeclareOptionX{justified}{\toggletrue{justified}}
 
 % Default Settings
-\ExecuteOptionsX{bg-full}
+\ExecuteOptionsX{bg=full}
 \ProcessOptionsX\relax
 
 % Set paragraph and line spacing

--- a/example.tex
+++ b/example.tex
@@ -22,11 +22,6 @@
 \usepackage{lipsum}
 \usepackage{listings}
 
-% dnd package options 
-% bg-full   : Default option. Use paper background and fancy footer.
-% bg-print  : Use fancy footer but not background.
-% bg-none   : No paper background and plain footer.
-% justified : Use full justification for text layout instead of ragged right.
 \usepackage{dnd}
 
 \lstset{%


### PR DESCRIPTION
Changes:

* Switches package option processing to xkeyval.
* Deprecates `bg-{mode}` package options in favour of single `bg` option.

Using key-value options offers a logical and user-friendly way to group settings. It also lets us handle user input at the package level without resorting to commands.

For example, we could allow XeTeX users to disable the CC fonts in #16 using something like `fonts=standard`. Or we might let users provide their own footer image using `footerscroll=<path>`.