### PR TITLE
Deactivate statblock bg on bg-print/bg-none

### DIFF
--- a/dnd.sty
+++ b/dnd.sty
@@ -33,19 +33,6 @@
   \PackageWarning{dnd}{#1 is deprecated and will be removed in version #2.\IfNoValueF{#3}{ #3}}
 }
 
-% Load other modules of this package
-\RequirePackage{lib/dndcolors}    % color definitions
-\RequirePackage{lib/dndfonts}     % font definitions
-\RequirePackage{lib/dndcomment}   % \commentbox definition
-\RequirePackage{lib/dndheader}    % fancy headers and footers
-\RequirePackage{lib/dndmonster}   % \monsterbox definition
-\RequirePackage{lib/dndpaperbox}  % \paperbox definition
-\RequirePackage{lib/dndquote}     % \quotebox definition
-\RequirePackage{lib/dndsections}  % section styling
-\RequirePackage{lib/dndspell}     % \spell definition
-\RequirePackage{lib/dndstrings}   % Load document strings
-\RequirePackage{lib/dndtable}     % \dndtable definition
-
 %
 % Options
 %
@@ -66,6 +53,20 @@
 % Default Settings
 \ExecuteOptions{bg-full}
 \ProcessOptions\relax
+
+% Load other modules of this package
+\RequirePackage{lib/dndcolors}    % color definitions
+\RequirePackage{lib/dndfonts}     % font definitions
+\RequirePackage{lib/dndcomment}   % \commentbox definition
+\RequirePackage{lib/dndheader}    % fancy headers and footers
+\RequirePackage{lib/dndmonster}   % \monsterbox definition
+\RequirePackage{lib/dndpaperbox}  % \paperbox definition
+\RequirePackage{lib/dndquote}     % \quotebox definition
+\RequirePackage{lib/dndsections}  % section styling
+\RequirePackage{lib/dndspell}     % \spell definition
+\RequirePackage{lib/dndstrings}   % Load document strings
+\RequirePackage{lib/dndtable}     % \dndtable definition
+
 
 % Set paragraph and line spacing
 \linespread{1.1}%

--- a/lib/dndcolors.sty
+++ b/lib/dndcolors.sty
@@ -34,7 +34,7 @@
 % Element colors that do not respond to \setthemecolor
 \colorlet{quoteboxcolor}{bgtan}             % quotebox background
 \definecolor{statblockribbon}{HTML}{E69A28} % stat block top/bottom borders (gold)
-\definecolor{statblockbg}{HTML}{FDF1DC}  % stat block background (tan)
+\definecolor{statblockbg}{HTML}{FDF1DC}     % stat block background (tan)
 
 % Sets the themecolor and colors for all themed elements
 % If called without the optional color, resets the color of all themed elements to the current themecolor

--- a/lib/dndcolors.sty
+++ b/lib/dndcolors.sty
@@ -34,11 +34,7 @@
 % Element colors that do not respond to \setthemecolor
 \colorlet{quoteboxcolor}{bgtan}             % quotebox background
 \definecolor{statblockribbon}{HTML}{E69A28} % stat block top/bottom borders (gold)
-\iftoggle{bool-bg}{
-	\definecolor{statblockbg}{HTML}{FDF1DC}  % stat block background (tan)
-}{
-	\definecolor{statblockbg}{HTML}{FFFFFF}  % stat block background (white)
-}
+\definecolor{statblockbg}{HTML}{FDF1DC}  % stat block background (tan)
 
 % Sets the themecolor and colors for all themed elements
 % If called without the optional color, resets the color of all themed elements to the current themecolor

--- a/lib/dndcolors.sty
+++ b/lib/dndcolors.sty
@@ -34,7 +34,11 @@
 % Element colors that do not respond to \setthemecolor
 \colorlet{quoteboxcolor}{bgtan}             % quotebox background
 \definecolor{statblockribbon}{HTML}{E69A28} % stat block top/bottom borders (gold)
-\definecolor{statblockbg}{HTML}{FDF1DC}     % stat block background (tan)
+\iftoggle{bool-bg}{
+	\definecolor{statblockbg}{HTML}{FDF1DC}  % stat block background (tan)
+}{
+	\definecolor{statblockbg}{HTML}{FFFFFF}  % stat block background (white)
+}
 
 % Sets the themecolor and colors for all themed elements
 % If called without the optional color, resets the color of all themed elements to the current themecolor

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -57,30 +57,36 @@
    #1
 }
 
+
 % new Monsterbox
-\newtcolorbox{monsterbox}[2][]{
-	enhanced,
-	frame hidden,
-	before skip=7pt plus2pt,
-	boxrule=0pt,
-	breakable,
-	boxsep=0.25ex,
-	toptitle=3mm,
-	left=2.5mm,
-	right=2.15mm,
-	arc=0mm,
-	borderline north={4pt}{0pt}{titlered},
-	borderline north={2.5pt}{0.75pt}{statblockribbon},
-	borderline south={4pt}{0pt}{titlered},
-	borderline south={2.5pt}{0.75pt}{statblockribbon},
-	colback=statblockbg,
-	colbacktitle=statblockbg,
-	colframe=titlered,
-	fonttitle=\dnd@StatBlockTitleFont\color{titlered}\Large,
-	fontupper=\dnd@StatBlockBodyFont,
-	title=#2,
-	after={\vspace{7pt plus 1pt}\noindent},
-	#1
+\iftoggle{bool-bg}{
+	\newtcolorbox{monsterbox}[2][]{
+		enhanced,
+		frame hidden,
+		before skip=7pt plus2pt,
+		boxrule=0pt,
+		breakable,
+		boxsep=0.25ex,
+		toptitle=3mm,
+		left=2.5mm,
+		right=2.15mm,
+		arc=0mm,
+		borderline north={4pt}{0pt}{titlered},
+		borderline north={2.5pt}{0.75pt}{statblockribbon},
+		borderline south={4pt}{0pt}{titlered},
+		borderline south={2.5pt}{0.75pt}{statblockribbon},
+		colback=statblockbg,
+		colbacktitle=statblockbg,
+		colframe=titlered,
+		fonttitle=\dnd@StatBlockTitleFont\color{titlered}\Large,
+		fontupper=\dnd@StatBlockBodyFont,
+		title=#2,
+		after={\vspace{7pt plus 1pt}\noindent},
+		#1
+	}
+}{
+	\let\monsterbox\monsterboxnobg
+	\let\endmonsterbox\endmonsterboxnobg
 }
 
 


### PR DESCRIPTION
This is to make `bg-print` and `bg-none` more printer friendly. The statblock delimiters are still very recognisable so it doesn't reduce legibility IMO.