### PR TITLE
Fix tcolorbox Title Color

### DIFF
--- a/lib/dndcomment.sty
+++ b/lib/dndcomment.sty
@@ -11,12 +11,13 @@
 	left=8pt,
 	right=8pt,
 	arc=0mm,
-	fonttitle=\dnd@BoxTitleFont\color{black},
+	fonttitle=\dnd@BoxTitleFont,
 	fontupper=\dnd@BoxBodyFont,
 	title={#2},
 	parbox=false,
 	colback={#3},
 	colbacktitle={#3},
+	coltitle=black,
 	after={\vspace{5pt plus 1pt}\noindent},
 	#1
 }

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -50,9 +50,10 @@
    arc=0mm,
    opacityback=0,
    colframe=titlered,
-   fonttitle=\dnd@StatBlockTitleFont\color{titlered}\Large,
+   fonttitle=\dnd@StatBlockTitleFont\Large,
    fontupper=\dnd@StatBlockBodyFont,
    title=#2,
+   coltitle=titlered,
    after={\vspace{7pt plus 1pt}\noindent},
    #1
 }
@@ -76,9 +77,10 @@
 	colback=statblockbg,
 	colbacktitle=statblockbg,
 	colframe=titlered,
-	fonttitle=\dnd@StatBlockTitleFont\color{titlered}\Large,
+	fonttitle=\dnd@StatBlockTitleFont\Large,
 	fontupper=\dnd@StatBlockBodyFont,
 	title=#2,
+  coltitle=titlered,
 	after={\vspace{7pt plus 1pt}\noindent},
 	#1
 }

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -5,12 +5,12 @@
 % Macro to print stats with autocomputed modifier
 % e.g. \stat{12} prints "12 (+1)"
 \newcommand{\stat}[1]{%
-   \FPeval{\mod}{(#1 - 10)/2}%
-   \FPifpos\mod%
-   \FPeval{\mod}{clip(trunc(mod,0))}#1\ (+\mod)%
-   \else%
-   \FPeval{\mod}{clip(abs(trunc(mod-0.5,0)))}#1\ (\(-\)\mod)%
-   \fi%
+	\FPeval{\mod}{(#1 - 10)/2}%
+	\FPifpos\mod%
+	\FPeval{\mod}{clip(trunc(mod,0))}#1\ (+\mod)%
+	\else%
+	\FPeval{\mod}{clip(abs(trunc(mod-0.5,0)))}#1\ (\(-\)\mod)%
+	\fi%
 }
 
 % Macro to print avarage dice based value
@@ -38,24 +38,24 @@
 
 % Monster box made to look like the Monster Manual NPC definitions
 \newtcolorbox{monsterboxnobg}[2][]{
-   enhanced,
-   frame hidden,
-   before skip=7pt plus2pt,
-   boxrule=0pt,
-   breakable,
-   boxsep=0.25ex,
-   toptitle=3mm,
-   left=2.5mm,
-   right=2.15mm,
-   arc=0mm,
-   opacityback=0,
-   colframe=titlered,
-   fonttitle=\dnd@StatBlockTitleFont\Large,
-   fontupper=\dnd@StatBlockBodyFont,
-   title=#2,
-   coltitle=titlered,
-   after={\vspace{7pt plus 1pt}\noindent},
-   #1
+	enhanced,
+	frame hidden,
+	before skip=7pt plus2pt,
+	boxrule=0pt,
+	breakable,
+	boxsep=0.25ex,
+	toptitle=3mm,
+	left=2.5mm,
+	right=2.15mm,
+	arc=0mm,
+	opacityback=0,
+	colframe=titlered,
+	fonttitle=\dnd@StatBlockTitleFont\Large,
+	fontupper=\dnd@StatBlockBodyFont,
+	title=#2,
+	coltitle=titlered,
+	after={\vspace{7pt plus 1pt}\noindent},
+	#1
 }
 
 % new Monsterbox
@@ -80,7 +80,7 @@
 	fonttitle=\dnd@StatBlockTitleFont\Large,
 	fontupper=\dnd@StatBlockBodyFont,
 	title=#2,
-  coltitle=titlered,
+	coltitle=titlered,
 	after={\vspace{7pt plus 1pt}\noindent},
 	#1
 }
@@ -93,7 +93,7 @@
 	\color{titlered}\dnd@StatBlockSubtitleFont\large #1 \vspace{3pt}
 	\titleline{\color{titlered}\titlerule[0.6pt]}
 	\par\medskip}
-	}
+}
 
 \newenvironment{monsteraction}[1][\unskip]{\emph{\textbf{#1.}}}{\vspace{0.5em}}
 
@@ -102,7 +102,7 @@
 %
 \newkeycommand\basics[armorclass=0, hitpoints=0, speed=0]{%
 	\color{titlered}
-  \textbf{\armorclassname} \commandkey{armorclass}\\
+	\textbf{\armorclassname} \commandkey{armorclass}\\
 	\textbf{\hitpointsname} \commandkey{hitpoints}\\
 	\textbf{\speedname} \commandkey{speed}\\
 }

--- a/lib/dndpaperbox.sty
+++ b/lib/dndpaperbox.sty
@@ -9,7 +9,7 @@
 	boxsep=0.25ex,
 	left=8pt,
 	right=8pt,
-	fonttitle=\dnd@BoxTitleFont\color{black},
+	fonttitle=\dnd@BoxTitleFont,
 	fontupper=\dnd@BoxBodyFont,
 	title={#2},
 	arc=0mm,
@@ -18,6 +18,7 @@
 	borderline south={1pt}{-0.5pt}{black},
 	colback={#3},
 	colbacktitle={#3},
+	coltitle=black,
 	fuzzy shadow={0mm}{-3.5pt}{-0.5pt}{0.4mm}{black!60!white},
 	overlay={%
 		\fill[black] (frame.south west) -- ++ (7pt,0) -- ++ (0,-5pt) -- cycle;


### PR DESCRIPTION
Moved the title color in the tcolorbox environments from fonttitle to coltitle. Having the color in fonttitle made it impossible to override the color.