### PR TITLE
minor hline and monsteraction formatting fixes

### DIFF
--- a/dnd.sty
+++ b/dnd.sty
@@ -141,6 +141,7 @@
   \begin{tikzpicture}[]
     \draw [rulered, fill=rulered] (0, 0) --(0,0.1) -- (\textwidth, 0.05);
   \end{tikzpicture}
+  \\
 }
 
 

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -102,8 +102,7 @@
 }
 
 \newenvironment{monsteraction}[1][\unskip]{
-	\smallskip\emph{\textbf{#1.}}
-}{}
+	\smallskip\emph{\textbf{#1.}}}{\\}
 
 %
 % Macros for use within the monster environment


### PR DESCRIPTION
1. Fixed weird first line spacing after the ```\hline```.
 Before/after sample:
 ![spacing1](https://user-images.githubusercontent.com/1783492/34748188-0280c8fe-f5a4-11e7-961e-dba84b119ec7.png)

2. Fixed unnaturally long space after the ```\monsteraction``` title.
 Before/after sample: 
![spacing2](https://user-images.githubusercontent.com/1783492/34748221-2cd38380-f5a4-11e7-9f5f-b55762e66bb7.png)

3. Added newline in the after-block for the actions separation if there was no spacing in the source, e.g.:
 ```
 ...
 \end{monsteraction}
 \begin{monsteraction}
 ...
 ```
 instead of
 ```
 ...
 \end{monsteraction}

 \begin{monsteraction}
 ...
 ```