### PR TITLE
Refactor \stats and \details internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
-* None
+* Removed dependency on package `hang`.
 
 ## [0.6.0] - 2017-10-12
 

--- a/dnd.sty
+++ b/dnd.sty
@@ -16,17 +16,20 @@
   bottom=50pt,        % .7in
   footskip=30pt,      % makes the footer text line up with the graphic
 ]{geometry}
+
+% Loaded before tikz to avoid package option conflict with pgf.
 \RequirePackage[table]{xcolor}
-\RequirePackage{hang}
+
 \RequirePackage{array}
-\RequirePackage{ifluatex}
-\RequirePackage{tabularx}
-\RequirePackage{tikz}
-\RequirePackage{keycommand}
-\RequirePackage[most]{tcolorbox}  % used for some boxes
+\RequirePackage{calc}
 \RequirePackage{enumitem}
+\RequirePackage{ifluatex}
+\RequirePackage{keycommand}
 \RequirePackage{microtype}        % Improve ragged2e hyphenation and overfull boxes
 \RequirePackage{ragged2e}
+\RequirePackage{tabularx}
+\RequirePackage[most]{tcolorbox}  % used for some boxes
+\RequirePackage{tikz}
 \RequirePackage{xkeyval}
 \RequirePackage{xparse}
 

--- a/example.tex
+++ b/example.tex
@@ -19,6 +19,7 @@
 % please refer to babel/polyglossia's documentation.
 
 \usepackage[utf8]{inputenc}
+\usepackage{hang}
 \usepackage{lipsum}
 \usepackage{listings}
 

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -104,22 +104,38 @@
 \newenvironment{monsteraction}[1][\unskip]{
 	\smallskip\emph{\textbf{#1.}}}{\\}
 
+% A description variant used to list creature attributes.
+\newlist{dnd@monsterattrs}{description}{1}
+\setlist[dnd@monsterattrs]{
+    before=\color{titlered},
+    font=\dnd@StatBlockBodyFont\textbf,
+    labelsep=\widthof{ },
+    noitemsep,
+    nosep,
+}
+
+% A dnd@monsterattrs helper macro that always displays an attribute.
+\newcommand{\dnd@monsterattr}[2]{%
+  \item[#2] \commandkey{#1}
+}
+
+% A dnd@monsterattrs helper macro that displays an attribute if the user defined
+% it.
+\newcommand{\dnd@ifmonsterattr}[2]{%
+  \ifcommandkey{#1}{%
+    \item[#2] \commandkey{#1}
+  }{}%
+}
+
 %
 % Macros for use within the monster environment
 %
 \newkeycommand\basics[armorclass=0, hitpoints=0, speed=0]{%
-	\begingroup
-		\unskip\color{titlered}
-		\begin{hangingpar}
-			\textbf{\armorclassname} \commandkey{armorclass}
-		\end{hangingpar}
-		\begin{hangingpar}
-			\textbf{\hitpointsname} \commandkey{hitpoints}
-		\end{hangingpar}
-		\begin{hangingpar}
-			\textbf{\speedname} \commandkey{speed}
-		\end{hangingpar}%
-	\endgroup%
+  \begin{dnd@monsterattrs}
+    \dnd@monsterattr{armorclass}{\armorclassname}
+    \dnd@monsterattr{hitpoints}{\hitpointsname}
+    \dnd@monsterattr{speed}{\speedname}
+  \end{dnd@monsterattrs}%
 }
 
 % Taubular enviornment for stats-block
@@ -142,52 +158,28 @@
     \endgroup
 }
 
-\newkeycommand\details[skills=,
-						damageimmunities=,
-						savingthrows=,
-						conditionimmunities=,
-						damageresistances=,
-						damagevulnerabilities=,
-						senses=---,
-						languages=---,
-						challenge=0]{%
-	\begingroup
-		\unskip\color{titlered}
-		\ifcommandkey{savingthrows}{%
-			\begin{hangingpar}
-			\textbf{\savesname} \commandkey{savingthrows}
-			\end{hangingpar}}{}%
-		\ifcommandkey{skills}{%
-			\begin{hangingpar}
-				\textbf{\skillsname} \commandkey{skills}
-			\end{hangingpar}}{}%
-		\ifcommandkey{damagevulnerabilities}{%
-			\begin{hangingpar}
-				\textbf{\dvulname} \commandkey{damagevulnerabilities}
-			\end{hangingpar}}{}%
-		\ifcommandkey{damageresistances}{%
-			\begin{hangingpar}
-				\textbf{\dresname} \commandkey{damageresistances}
-			\end{hangingpar}}{}%
-		\ifcommandkey{damageimmunities}{%
-			\begin{hangingpar}
-				\textbf{\dimmname} \commandkey{damageimmunities}
-			\end{hangingpar}}{}%
-		\ifcommandkey{conditionimmunities}{%
-			\begin{hangingpar}
-				\textbf{\cimmname} \commandkey{conditionimmunities}
-			\end{hangingpar}}{}%
-		% These traits appear to always be present.
-		\begin{hangingpar}
-			\textbf{\sensesname} \commandkey{senses}
-		\end{hangingpar}
-		\begin{hangingpar}
-			\textbf{\languagesname} \commandkey{languages}
-		\end{hangingpar}
-		\begin{hangingpar}
-			\textbf{\challengename} \crexp{\commandkey{challenge}}
-		\end{hangingpar}%
-	\endgroup%
+\newkeycommand\details[
+  skills=,
+  damageimmunities=,
+  savingthrows=,
+  conditionimmunities=,
+  damageresistances=,
+  damagevulnerabilities=,
+  senses=---,
+  languages=---,
+  challenge=1,
+  ]{%
+  \begin{dnd@monsterattrs}
+    \dnd@ifmonsterattr{savingthrows}{\savesname}
+    \dnd@ifmonsterattr{skills}{\skillsname}
+    \dnd@ifmonsterattr{damagevulnerabilities}{\dvulname}
+    \dnd@ifmonsterattr{damageresistances}{\dresname}
+    \dnd@ifmonsterattr{damageimmunities}{\dimmname}
+    \dnd@ifmonsterattr{conditionimmunities}{\cimmname}
+    \dnd@monsterattr{senses}{\sensesname}
+    \dnd@monsterattr{languages}{\languagesname}
+    \item[\challengename] \crexp{\commandkey{challenge}}
+  \end{dnd@monsterattrs}%
 }
 
 \newcommand\crexp[1]{%


### PR DESCRIPTION
While looking at #96, I decided to refactor the `\stats` and `\details` internals.

Like the `spell` environment, these now use a custom `description` environment.

| Before | After |
|-|-|
| ![before](https://user-images.githubusercontent.com/358027/37256822-07179b5a-259b-11e8-9687-400f761f8c86.png) | ![after](https://user-images.githubusercontent.com/358027/37256821-06e390d0-259b-11e8-9341-f69ad60c009e.png) |