### PR TITLE
Fix miscellaneous monsterbox issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * Allow `\monstersection` before sectioning command(s).
+* Removed excess space after `\dice`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-* None
+* Allow `\monstersection` before sectioning command(s).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Made `monsterbox` text the width of the column and the background spills into margin and column separator.
 * Removed excess space before and after `monsterbox`.
 * Challenge rating on `monsterbox` now only needs the CR number.
+* `monsterbox` renamed `monsterboxbg`. `monsterbox` is now an alias that maps to `monsterboxbg` or `monsterboxnobg`, depending on the value of the `bg` package option.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Allow `\monstersection` before sectioning command(s).
 * Removed excess space after `\dice`.
+* `monsteraction`: Only add a period to the action name if provided one.
 
 ### Deprecated
 

--- a/dnd.sty
+++ b/dnd.sty
@@ -141,12 +141,12 @@
 \renewcommand{\labelitemi}{\raisebox{0.25ex}{\tiny{\( \bullet \)}}}
 
 % Fancy DnD 5e-style hline
-\renewcommand{\hline}{
+\renewcommand{\hline}{%
   \noindent
   \begin{tikzpicture}[]
     \draw [rulered, fill=rulered] (0, 0) --(0,0.1) -- (\textwidth, 0.05);
-  \end{tikzpicture}
-  \\
+  \end{tikzpicture}%
+  \par%
 }
 
 

--- a/dnd.sty
+++ b/dnd.sty
@@ -140,13 +140,17 @@
 \setitemize{noitemsep,topsep=0.5ex}
 \renewcommand{\labelitemi}{\raisebox{0.25ex}{\tiny{\( \bullet \)}}}
 
-% Fancy DnD 5e-style hline
-\renewcommand{\hline}{%
+% Fancy DnD 5e stat block rule
+\newcommand{\dndline}{%
   \noindent
   \begin{tikzpicture}[]
     \draw [rulered, fill=rulered] (0, 0) --(0,0.1) -- (\textwidth, 0.05);
   \end{tikzpicture}%
   \par%
+}
+\renewcommand{\hline}{%
+  \dnd@deprecate{redefined hline}{0.7}[Use dndline for stat block rules.]%
+  \dndline%
 }
 
 

--- a/example.tex
+++ b/example.tex
@@ -78,25 +78,25 @@
   \begin{hangingpar}
     \textit{Small metasyntactic variable (goblinoid), neutral evil}
   \end{hangingpar}
-	\hline%
+	\dndline%
 	\basics[%
 	armorclass = 12,
 	hitpoints  = \dice{3d8 + 3},
 	speed      = 50 ft
 	]
-	\hline%
+	\dndline%
 	\stats[
     STR = \stat{12}, % This stat command will autocomplete the modifier for you
     DEX = \stat{7}
 	]
-	\hline%
+	\dndline%
 	\details[%
 	% If you want to use commas in these sections, enclose the
 	% description in braces.
 	% I'm so sorry.
 	languages = {Common Lisp, Erlang},
 	]
-	\hline%
+	\dndline%
 	\begin{monsteraction}[Monster-super-powers]
 		This Monster has some serious superpowers!
 	\end{monsteraction}

--- a/example.tex
+++ b/example.tex
@@ -96,7 +96,7 @@
 	% I'm so sorry.
 	languages = {Common Lisp, Erlang},
 	]
-	\hline \\[1mm]
+	\hline%
 	\begin{monsteraction}[Monster-super-powers]
 		This Monster has some serious superpowers!
 	\end{monsteraction}

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -103,8 +103,11 @@
   \endgroup
 }
 
-\newenvironment{monsteraction}[1][\unskip]{
-	\smallskip\emph{\textbf{#1.}}}{\\}
+\NewDocumentEnvironment{monsteraction}{o}{%
+  \IfValueTF{#1}{%
+    \smallskip\emph{\textbf{#1.}}%
+  }{\unskip}%
+}{\\}
 
 %
 % Macros for use within the monster environment

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -94,7 +94,7 @@
 
 
 % Define Monster subsection header style
-\newcommand{\monstersection}[1]{
+\newcommand{\monstersection}[1]{%
   \begingroup
     \par\medskip\color{titlered}
     \dnd@StatBlockSubtitleFont\large #1
@@ -103,14 +103,14 @@
     \vspace{3pt}
     \hrule height 0.6pt
     \vspace{3pt}
-  \endgroup
+  \endgroup%
 }
 
 \NewDocumentEnvironment{monsteraction}{o}{%
   \IfValueTF{#1}{%
     \smallskip\emph{\textbf{#1.}}%
   }{\unskip}%
-}{\\}
+}{\par}
 
 %
 % Macros for use within the monster environment

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -91,14 +91,16 @@
 
 
 % Define Monster subsection header style
-%\newcommand{\monstersection}[1]{\subsubsection*{#1}}
 \newcommand{\monstersection}[1]{
-	\begingroup
-		\par\medskip\color{titlered}
-		\dnd@StatBlockSubtitleFont\large #1 \vspace{3pt}
-		\titleline{\titlerule[0.6pt]}
-		\vspace{3pt}
-	\endgroup
+  \begingroup
+    \par\medskip\color{titlered}
+    \dnd@StatBlockSubtitleFont\large #1
+    % \rule is a horizontal command, so placing it under the title incurs extra
+    % line spacing. Use \hrule (a vertical command) instead.
+    \vspace{3pt}
+    \hrule height 0.6pt
+    \vspace{3pt}
+  \endgroup
 }
 
 \newenvironment{monsteraction}[1][\unskip]{

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -56,37 +56,40 @@
 	#1
 }
 
-% new Monsterbox
+% Stat block made to look like stat blocks in the PHB.
+\newtcolorbox{monsterboxbg}[2][]{
+  enhanced,
+  frame hidden,
+  before skip=7pt plus 2pt,
+  boxrule=0pt,
+  breakable,
+  boxsep=0pt,
+  toptitle=11pt,
+  left=7pt,
+  right=7pt,
+  bottom=11pt,
+  arc=0mm,
+  oversize=0pt,
+  borderline north={4pt}{0pt}{titlered},
+  borderline north={2.5pt}{0.75pt}{statblockribbon},
+  borderline south={4pt}{0pt}{titlered},
+  borderline south={2.5pt}{0.75pt}{statblockribbon},
+  colback=statblockbg,
+  colbacktitle=statblockbg,
+  colframe=titlered,
+  fonttitle=\dnd@StatBlockTitleFont\Large,
+  coltitle=titlered,
+  fontupper=\dnd@StatBlockBodyFont,
+  title=#2,
+  #1
+}
+
 \iftoggle{bool-bg}{
-	\newtcolorbox{monsterbox}[2][]{
-		enhanced,
-		frame hidden,
-		before skip=7pt plus 2pt,
-		boxrule=0pt,
-		breakable,
-		boxsep=0pt,
-		toptitle=11pt,
-		left=7pt,
-		right=7pt,
-		bottom=11pt,
-		arc=0mm,
-		oversize=0pt,
-		borderline north={4pt}{0pt}{titlered},
-		borderline north={2.5pt}{0.75pt}{statblockribbon},
-		borderline south={4pt}{0pt}{titlered},
-		borderline south={2.5pt}{0.75pt}{statblockribbon},
-		colback=statblockbg,
-		colbacktitle=statblockbg,
-		colframe=titlered,
-		fonttitle=\dnd@StatBlockTitleFont\Large,
-		coltitle=titlered,
-		fontupper=\dnd@StatBlockBodyFont,
-		title=#2,
-		#1
-	}
+  \let\monsterbox\monsterboxbg%
+  \let\endmonsterbox\endmonsterboxbg%
 }{
-	\let\monsterbox\monsterboxnobg%
-	\let\endmonsterbox\endmonsterboxnobg%
+  \let\monsterbox\monsterboxnobg%
+  \let\endmonsterbox\endmonsterboxnobg%
 }
 
 

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -33,7 +33,7 @@
 		}%
 	}%
 	\FPtrunc{\DiceAvg}{\DiceAvg}{0}%				round down
-	\FPprint{\DiceAvg\ (\DiceNum d\DiceSides\DiceMod)}
+	\FPprint{\DiceAvg\ (\DiceNum d\DiceSides\DiceMod)}%
 }
 
 % Monster box made to look like the Monster Manual NPC definitions


### PR DESCRIPTION
This changeset fixes a handful of `monsterbox` issues:

* We can now use `\monstersection` before declaring the first `\chapter`, `\section`, or other section.

    Previously, users received this error:

    ```
    ! Undefined control sequence.
    <argument> \ttl@makeline
                             {{\titlerule [0.6pt]}}
    l.14    \monstersection{Actions}
    ```

    **Corollary:** we can use it in documents without sections.
* Fixes extra spacing after the `\dice` macro (see the damage rolls below).
* Creating a `monsteraction` without a title no longer introduces a stray period.<sup>1</sup>
* Renames `monsterbox` to `monsterboxbg` and sets up the `monsterbox` alias as described in #92.

| Before | After |
|-|-|
| ![before](https://user-images.githubusercontent.com/358027/37568461-5e06f0f8-2b10-11e8-8ae5-567fb0e27cab.png) | ![after](https://user-images.githubusercontent.com/358027/37568464-64c35986-2b10-11e8-8dd5-d01d596fe321.png) |

Notes:

1. I don't think the `monsteraction` description should be an optional argument. I can't find any examples of an action without a name or short description. I'm not sure how to deprecate it, though.