### PR TITLE
Add dndbook class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 * Added `bg` package option with `full`, `print`, and `none` as possible values.
+* Added boolean `layout` package option to control whether the package formats the document on load.
 * Added `nomultitoc` package option to toggle multi-column table of contents.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added `bg` package option with `full`, `print`, and `none` as possible values.
 * Added boolean `layout` package option to control whether the package formats the document on load.
 * Added `nomultitoc` package option to toggle multi-column table of contents.
+* Added `dndbook` document class.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -61,20 +61,48 @@ TEXINPUTS=./lib//: pdflatex project.tex
 
 ## Usage
 
-Load the template in your preamble:
+### Class (recommended)
+
+Load the `dndbook` class in your preamble:
+
+```tex
+\documentclass[10pt,twoside,twocolumn,openany]{dndbook}
+
+\usepackage[english]{babel}
+\usepackage[utf8]{inputenc}
+
+\begin{document}
+% ...
+```
+
+### Package
+
+You can also load the `dnd` package directly to use it with another class.
+Note that the package has only been tested with the `book` class.
 
 ```tex
 \documentclass[10pt,twoside,twocolumn,openany]{book}
 
 \usepackage[english]{babel}
 \usepackage[utf8]{inputenc}
-\usepackage{dnd}
+
+\usepackage[layout=true]{dnd}
 
 \begin{document}
 % ...
 ```
 
-### Package options
+### Options
+
+| Option         | Package `dnd`   | Class `dndbook`   |
+| -------------- | :-------------: | :---------------: |
+| `bg`           | ✓               | ✓                 |
+| `justified`    | ✓               | ✓                 |
+| `layout`       | ✓               |                   |
+| `nomultitoc`   | ✓               | ✓                 |
+
+
+The `dndbook` class also supports all the options of the `book` class.
 
 #### `bg`
 
@@ -87,6 +115,17 @@ Declare how to load background and footer images. This is a key-value option wit
 #### `justified`
 
 Justify column copy.
+
+#### `layout`
+
+Controls whether loading the `dnd` package also modifies the document layout (geometry, colors, typography, etc.).
+This is a boolean option with the following possible values:
+
+* `true`: Modify the document layout.
+* `false`: Do not modify the document layout.
+
+The default value is `true` for backwards compatibility with early releases.
+This will change in a future release.
 
 #### `nomultitoc`
 

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -90,7 +90,7 @@ main() {
   if [[ -z $dry_run ]]; then
     sed -e '/ProvidesPackage/ s#'"${current_date}"'#'"${new_date}"'#' \
         -e '/ProvidesPackage/ s#'"v${current_version}"'#'"v${new_version}"'#' \
-        -i dnd.sty
+        -i dnd.sty dndbook.cls
     sed 's/'"${current_version}"'/'"${new_version}"'/g' -i README.md
 
     git add README.md dnd.sty

--- a/dnd.sty
+++ b/dnd.sty
@@ -8,14 +8,6 @@
 %
 % Prerequisite Packages
 %
-% Set a different geometry with \newgeometry
-\usepackage[
-  bindingoffset=15pt, % .2in
-  hmargin=50pt,       % .7in
-  top=40pt,           % .55in
-  bottom=50pt,        % .7in
-  footskip=30pt,      % makes the footer text line up with the graphic
-]{geometry}
 
 % Loaded before tikz to avoid package option conflict with pgf.
 \RequirePackage[table]{xcolor}
@@ -23,10 +15,9 @@
 \RequirePackage{array}
 \RequirePackage{calc}
 \RequirePackage{enumitem}
+\RequirePackage{geometry}
 \RequirePackage{ifluatex}
 \RequirePackage{keycommand}
-\RequirePackage{microtype}        % Improve ragged2e hyphenation and overfull boxes
-\RequirePackage{ragged2e}
 \RequirePackage{tabularx}
 \RequirePackage[most]{tcolorbox}  % used for some boxes
 \RequirePackage{tikz}
@@ -99,23 +90,26 @@
 \settoggle{multitoc}{true}
 \DeclareOptionX{nomultitoc}{\togglefalse{multitoc}}
 
+% Adds boolean `layout` package option and \ifpkglayout if command.
+\define@boolkey{dnd.sty}[pkg]{layout}[true]{}
+
 % Default Settings
-\ExecuteOptionsX{bg=full}
+\ExecuteOptionsX{bg=full, layout=true}
 \ProcessOptionsX\relax
 
-% Load other modules of this package
-\RequirePackage{lib/dndcolors}    % color definitions
-\RequirePackage{lib/dndfonts}     % font definitions
-\RequirePackage{lib/dndcomment}   % \commentbox definition
-\RequirePackage{lib/dndheader}    % fancy headers and footers
-\RequirePackage{lib/dndmonster}   % \monsterbox definition
-\RequirePackage{lib/dndpaperbox}  % \paperbox definition
-\RequirePackage{lib/dndquote}     % \quotebox definition
-\RequirePackage{lib/dndsections}  % section styling
-\RequirePackage{lib/dndspell}     % \spell definition
-\RequirePackage{lib/dndstrings}   % Load document strings
-\RequirePackage{lib/dndtable}     % \dndtable definition
+\ifpkglayout
 
+\RequirePackage{microtype}        % Improve ragged2e hyphenation and overfull boxes
+\RequirePackage{ragged2e}
+
+% Set page geometry.
+\geometry{%
+  bindingoffset=15pt, % .2in
+  hmargin=50pt,       % .7in
+  top=40pt,           % .55in
+  bottom=50pt,        % .7in
+  footskip=30pt,      % makes the footer text line up with the graphic
+}
 
 % Set paragraph and line spacing
 \linespread{1.1}%
@@ -134,12 +128,6 @@
 % Disable space between paragraphs.
 \setlength{\parskip}{0pt}
 
-% Font environment
-\newenvironment{lmss}{%
-  \dnd@deprecate{lmss}{0.7}
-  \fontfamily{lmss}\selectfont
-  }{}
-
 % Columns setup
 \setlength{\columnsep}{25pt}  % .35in
 
@@ -147,6 +135,8 @@
 \setlist{leftmargin=1em}
 \setitemize{noitemsep,topsep=0.5ex}
 \renewcommand{\labelitemi}{\raisebox{0.25ex}{\tiny{\( \bullet \)}}}
+
+\fi % \ifpkglayout
 
 % Fancy DnD 5e stat block rule
 \newcommand{\dndline}{%
@@ -177,3 +167,25 @@
         \kcmd@nbk \commandkey {#1}//{first}{second}//oftwo\endcsname
       }
    }
+
+
+% Font environment
+\newenvironment{lmss}{%
+  \dnd@deprecate{lmss}{0.7}
+  \fontfamily{lmss}\selectfont
+  }{}
+
+
+% Load other modules of this package after all dependencies to avoid load order
+% conflicts (e.g., package options).
+\RequirePackage{lib/dndcolors}    % color definitions
+\RequirePackage{lib/dndfonts}     % font definitions
+\RequirePackage{lib/dndcomment}   % \commentbox definition
+\RequirePackage{lib/dndheader}    % fancy headers and footers
+\RequirePackage{lib/dndmonster}   % \monsterbox definition
+\RequirePackage{lib/dndpaperbox}  % \paperbox definition
+\RequirePackage{lib/dndquote}     % \quotebox definition
+\RequirePackage{lib/dndsections}  % section styling
+\RequirePackage{lib/dndspell}     % \spell definition
+\RequirePackage{lib/dndstrings}   % Load document strings
+\RequirePackage{lib/dndtable}     % \dndtable definition

--- a/dndbook.cls
+++ b/dndbook.cls
@@ -1,0 +1,26 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{dndbook}[2017/10/13 v0.6.0 Template for D&D 5e material]
+
+\RequirePackage{pgffor}
+\RequirePackage{xkeyval}
+\RequirePackage{xstring}
+
+% Pass these class options to the core dnd package.
+\newcommand{\dnd@packageoptions}{bg=, justified, nomultitoc}
+
+% Pass package options to dnd package; pass all other options to book class.
+\DeclareOptionX*{
+  \foreach \option in \dnd@packageoptions {
+    \IfBeginWith{\CurrentOption}{\option}{
+      \PassOptionsToPackage{\CurrentOption}{dnd}
+    }{
+      \PassOptionsToClass{\CurrentOption}{book}
+    }
+  }
+}
+\ProcessOptionsX*\relax
+
+\LoadClass{book}
+
+\PassOptionsToPackage{layout=true}{dnd}
+\RequirePackage{dnd}

--- a/dndbook.cls
+++ b/dndbook.cls
@@ -1,16 +1,15 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{dndbook}[2017/10/13 v0.6.0 Template for D&D 5e material]
 
-\RequirePackage{pgffor}
 \RequirePackage{xkeyval}
 \RequirePackage{xstring}
 
 % Pass these class options to the core dnd package.
-\newcommand{\dnd@packageoptions}{bg=, justified, nomultitoc}
+\newcommand{\dnd@packageoptions}{bg=,justified,nomultitoc}
 
 % Pass package options to dnd package; pass all other options to book class.
 \DeclareOptionX*{
-  \foreach \option in \dnd@packageoptions {
+  \@for \option:=\dnd@packageoptions \do{
     \IfBeginWith{\CurrentOption}{\option}{
       \PassOptionsToPackage{\CurrentOption}{dnd}
     }{

--- a/example.tex
+++ b/example.tex
@@ -2,7 +2,7 @@
 % rather than alternate every other.
 %
 % Note that the article class does not have chapters.
-\documentclass[letterpaper,10pt,twoside,twocolumn,openany]{book}
+\documentclass[letterpaper,10pt,twoside,twocolumn,openany]{dndbook}
 
 % Use babel or polyglossia to automatically redefine macros for terms
 % Armor Class, Level, etc...
@@ -22,8 +22,6 @@
 \usepackage{hang}
 \usepackage{lipsum}
 \usepackage{listings}
-
-\usepackage{dnd}
 
 \lstset{%
   basicstyle=\ttfamily,

--- a/lib/dndcomment.sty
+++ b/lib/dndcomment.sty
@@ -1,6 +1,10 @@
 %Usage \begin{commentbox}[options]{title}[color]
 \DeclareTColorBox{commentbox}{O{} m O{commentboxcolor}}{%
-	before upper={\nottoggle{justified}{\RaggedRight}},
+	before upper={%
+		\ifpkglayout%
+			\nottoggle{justified}{\RaggedRight}%
+		\fi%
+	},
 	frame hidden,
 	boxrule=0pt,
 	breakable,

--- a/lib/dndfonts.sty
+++ b/lib/dndfonts.sty
@@ -1,7 +1,8 @@
-\RequirePackage{bookman}
-\RequirePackage[T1]{fontenc}
-
-\renewcommand{\sfdefault}{lmss}
+\ifpkglayout
+  \RequirePackage{bookman}
+  \RequirePackage[T1]{fontenc}
+  \renewcommand{\sfdefault}{lmss}
+\fi
 
 \newcommand{\dnd@TitleFont}{\normalfont\scshape}
 

--- a/lib/dndheader.sty
+++ b/lib/dndheader.sty
@@ -1,3 +1,5 @@
+\ifpkglayout
+
 \RequirePackage{fancyhdr} 			  % Adaptation of the footers
 
 % Setup for custom footer
@@ -56,3 +58,5 @@
 }
 
 \fancypagestyle{plain}{}
+
+\fi % \ifpkglayout

--- a/lib/dndpaperbox.sty
+++ b/lib/dndpaperbox.sty
@@ -1,6 +1,10 @@
 %Usage \begin{paperbox}[options]{title}[color]
 \DeclareTColorBox{paperbox}{O{} m O{paperboxcolor}}{%
-	before upper={\nottoggle{justified}{\RaggedRight}},
+	before upper={%
+		\ifpkglayout%
+			\nottoggle{justified}{\RaggedRight}%
+		\fi%
+	},
 	frame hidden,
 	boxrule=0pt,
 	enhanced,

--- a/lib/dndquote.sty
+++ b/lib/dndquote.sty
@@ -1,6 +1,10 @@
 %Usage \begin{quotebox}[options][color]
 \DeclareTColorBox{quotebox}{O{} O{quoteboxcolor}}{%
-  before upper={\nottoggle{justified}{\RaggedRight}},
+	before upper={%
+		\ifpkglayout%
+			\nottoggle{justified}{\RaggedRight}%
+		\fi%
+	},
 	code={\linespread{1.25}},
 	enhanced jigsaw,
 	frame hidden,

--- a/lib/dndsections.sty
+++ b/lib/dndsections.sty
@@ -1,3 +1,5 @@
+\ifpkglayout
+
 \RequirePackage[titles]{tocloft}
 \RequirePackage{titlesec}	% Used to adjust (sub)section formatting
 
@@ -41,8 +43,10 @@
 \titlespacing*{\subparagraph}
 {\parindent}{\parskip}{\wordsep}
 
+\fi % \ifpkglayout
+
 % Special command for magic items, traps, and the like.
 \newcommand{\subtitlesection}[2]{
 	\subsubsection{#1}\vspace{-1ex}
 	\textit{#2}\vspace{1ex}\par
-	} 
+	}

--- a/lib/dndstrings.sty
+++ b/lib/dndstrings.sty
@@ -22,11 +22,19 @@
 \newcommand\challengename{Challenge}
 
 
-% Check if either babel or polyglossia have been loaded,
-% in which case load the string captions
-\@ifpackageloaded{babel}{
-  \usepackage{lib/dndstrings-captions}
-}{}
-\@ifpackageloaded{polyglossia}{
-  \usepackage{lib/dndstrings-captions}
-}{}
+% Delay loading captions until after the user has imported a language package.
+% Enables using babel/polyglossia with the dndbook document class as well as the
+% dnd package.
+%
+% Both language packages use \AtBeginDocument. Use \AtEndPreamble (etoolbox)
+% instead to side-step load order issues.
+\AtEndPreamble{%
+  % Check if either babel or polyglossia have been loaded,
+  % in which case load the string captions
+  \@ifpackageloaded{babel}{
+    \usepackage{lib/dndstrings-captions}
+  }{}
+  \@ifpackageloaded{polyglossia}{
+    \usepackage{lib/dndstrings-captions}
+  }{}
+}


### PR DESCRIPTION
This changeset adds a `dndbook` document class, based on the standard `book` class.

Using this template is now as easy as:

```tex
\documentclass[twocolumn,openany]{dndbook}
```

The class is just a very thin wrapper around the package, which still contains all the presentation logic. It's possible to load the package without any presentation side-effects using the `layout` option:

```tex
\usepackage[layout=false]{dnd}
```

The `layout` option defaults to `true` for now, so this is entirely backwards compatible. I suggest we change the default in the future to encourage users to switch to the class.

Closes #109 