### PR TITLE
Added \dndcoverpage command. Installation of AndadaSC font recommended.

### DIFF
--- a/dnd.sty
+++ b/dnd.sty
@@ -115,6 +115,7 @@
 \RequirePackage{lib/dndspell}     % \spell definition
 \RequirePackage{lib/dndstrings}   % Load document strings
 \RequirePackage{lib/dndtable}     % \dndtable definition
+\RequirePackage{lib/dndcoverpage} % \dndcoverpage definition
 
 
 % Set paragraph and line spacing

--- a/lib/dndcoverpage.sty
+++ b/lib/dndcoverpage.sty
@@ -1,0 +1,39 @@
+\RequirePackage{xcolor}
+\RequirePackage{pdfrender}
+\RequirePackage{pgfkeys}
+
+\definecolor{CharFillColor}{rgb}{1,1,1}
+
+% commands:
+%	required: background image, text
+%	optional: text width, offsetx, offset y, fontsize, baselinestretch, outline width
+
+\pgfkeys{
+	/dndcoverpage/.is family, /dndcoverpage,
+	default/.style = {width = 0.7\paperwidth, offsetX=0, offsetY=0, fontsize=50, outlineWidth=2}, %height = \baselineskip?
+	width/.store in = \dndWidth,
+	offsetX/.store in = \dndOffsetX,
+	offsetY/.store in = \dndOffsetY,
+	fontsize/.store in = \dndFontsize,
+	outlineWidth/.store in = \dndOutlineWidth,
+}
+
+\newcommand{\dndcoverpage}[3][]{
+	\pgfkeys{/dndcoverpage, default, #1}
+	
+	\thispagestyle{empty} % prevents the footer from appearing on the cover page
+	\begin{tikzpicture}[remember picture,overlay,shift={(current page.center)}]
+		\node[inner sep=0pt] at (current page.center) {
+			\includegraphics[width=\paperwidth,height=\paperheight]{#3} %file ending is only necessary if it's not a .png
+		};
+		\node[text width=\dndWidth, align=center] at (\dndOffsetX,\dndOffsetY) {
+			\textpdfrender{
+				TextRenderingMode=FillStroke,
+				LineWidth=\dndOutlineWidth pt,
+				FillColor=CharFillColor,
+			}{
+				\fontsize{\dndFontsize}{1}\selectfont \bfseries \scshape \dnd@CoverFont #2
+			}
+		};
+	\end{tikzpicture}
+}

--- a/lib/dndfonts.sty
+++ b/lib/dndfonts.sty
@@ -1,5 +1,7 @@
 \RequirePackage{bookman}
 \RequirePackage[T1]{fontenc}
+\RequirePackage{fontspec}
+\RequirePackage{noto}
 
 \renewcommand{\sfdefault}{lmss}
 
@@ -17,3 +19,12 @@
 
 \newcommand{\dnd@FooterFont}{\normalfont\scshape}
 \newcommand{\dnd@PageNumberFont}{\normalfont}
+
+\newcommand{\dnd@CoverFont}{
+	\IfFontExistsTF{AndadaSC-Bold}{
+		\newfontfamily\coverFont{AndadaSC-Bold}
+	}{
+		\newfontfamily\coverFont{NotoSerif}
+	}
+	\coverFont
+}


### PR DESCRIPTION
If you don't have *AndadaSC* installed (available [here](https://www.1001fonts.com/andada-font.html); install into `TEXMF/fonts/opentype/andada`), the NotoSerif font will be used. It's doesn't look as good as *AndadaSC*, but it'll avoid compile crashes.

`\dndcoverpage` command has two mandatory arguments, the first one being the title itself, and the second one being the background image (which should ideally be in the same format that your document is using, otherwise it will get stretched and look ugly).

You can also specify optional arguments by passing in key-value-pairs. Available are `width`, `offsetX`, `offsetY`, `fontsize` and `outlineWidth`.
The width specifies how wide your title can get. Default is `0.7\paperwidth`, i.e. 70% of the page width.
The x- and y-offset specify how far off from the page center you want your title to be. Defaults are `0`.
The fontsize should be self-explanatory (default is `50`), and the outline width specifies the thickness of the text's outline (default `2pt`).

Usage example:
`\dndcoverpage[fontsize=80, offsetY=9]{My Title}{background.jpg}`