### PR TITLE
Set fontlower on all tcolorbox boxes

### DIFF
--- a/lib/dndcomment.sty
+++ b/lib/dndcomment.sty
@@ -13,6 +13,7 @@
 	arc=0mm,
 	fonttitle=\dnd@BoxTitleFont,
 	fontupper=\dnd@BoxBodyFont,
+	fontlower=\dnd@BoxBodyFont,
 	title={#2},
 	parbox=false,
 	colback={#3},

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -51,6 +51,7 @@
 	colframe=titlered,
 	fonttitle=\dnd@StatBlockTitleFont\Large,
 	fontupper=\dnd@StatBlockBodyFont,
+	fontlower=\dnd@StatBlockBodyFont,
 	title=#2,
 	coltitle=titlered,
 	#1
@@ -80,6 +81,7 @@
   fonttitle=\dnd@StatBlockTitleFont\Large,
   coltitle=titlered,
   fontupper=\dnd@StatBlockBodyFont,
+  fontlower=\dnd@StatBlockBodyFont,
   title=#2,
   #1
 }

--- a/lib/dndpaperbox.sty
+++ b/lib/dndpaperbox.sty
@@ -11,6 +11,7 @@
 	right=8pt,
 	fonttitle=\dnd@BoxTitleFont,
 	fontupper=\dnd@BoxBodyFont,
+	fontlower=\dnd@BoxBodyFont,
 	title={#2},
 	arc=0mm,
 	parbox=false,

--- a/lib/dndquote.sty
+++ b/lib/dndquote.sty
@@ -17,6 +17,7 @@
 	borderline west={1pt}{-0.5pt}{titlered},
 	borderline east={1pt}{-0.5pt}{titlered},
 	fontupper=\dnd@BoxBodyFont,
+	fontlower=\dnd@BoxBodyFont,
 	overlay={%
 		\foreach\n in {north east,north west,south east,south west}
 		{\draw[titlered, fill=titlered] (frame.\n) circle (2pt); }; },


### PR DESCRIPTION
Obviates font hack raised in #128.

This is a no-op unless the user calls `\tcblower`.