### PR TITLE
Redefine \cftchapfont if and only if it exists

### DIFF
--- a/lib/dndsections.sty
+++ b/lib/dndsections.sty
@@ -14,7 +14,9 @@
 
 \titlespacing*{\chapter}{0pt}{0pt}{20pt}
 
-\renewcommand\cftchapfont{\color{titlered}\dnd@TitleFont\bfseries}
+\ifdef{\cftchapfont}{%
+  \renewcommand\cftchapfont{\color{titlered}\dnd@TitleFont\bfseries}
+}{}
 
 % Section
 \titleformat{\section}


### PR DESCRIPTION
Allows using the package with the `article` class, which does not
provide chapters.

Fixes #126