### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+---
+sudo: false
+language: generic
+
+cache:
+  directories:
+    - /tmp/texlive
+    - $HOME/.texlive
+
+env:
+  global:
+    - PATH=/tmp/texlive/bin/x86_64-linux:$PATH
+
+matrix:
+  include:
+    - env: LATEX=pdflatex
+    - env: LATEX=lualatex
+
+install:
+  - ./bin/install-texlive
+
+script:
+  - make

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Removed excess space before and after `monsterbox`.
 * Challenge rating on `monsterbox` now only needs the CR number.
 * `monsterbox` renamed `monsterboxbg`. `monsterbox` is now an alias that maps to `monsterboxbg` or `monsterboxnobg`, depending on the value of the `bg` package option.
+* Limited set of pre-loaded `tcolorbox` libraries to `breakable`, `skins`, and `xparse`.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all clean
+
+LATEX ?= pdflatex
+
+all: example.pdf
+
+clean:
+	latexmk -C
+
+%.pdf: %.tex
+	latexmk --interaction=nonstopmode --pdf --pdflatex=$(LATEX) $<

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # D&D 5e LaTeX Template
 
 [![Latest release](https://img.shields.io/github/release/evanbergeron/DND-5e-LaTeX-Template/all.svg)](https://github.com/evanbergeron/DND-5e-LaTeX-Template/releases/latest)
+[![Build Status](https://travis-ci.org/evanbergeron/DND-5e-LaTeX-Template.svg?branch=master)](https://travis-ci.org/evanbergeron/DND-5e-LaTeX-Template)
 
 This is a LaTeX template for typesetting documents in the style of the *Dungeons & Dragons* 5th Edition (D&D 5e) books.
 

--- a/bin/install-texlive
+++ b/bin/install-texlive
@@ -16,10 +16,8 @@ tlmgr install dvips graphics graphics-def latex latex-bin latexmk
 
 # Package dependencies
 #   amsmath: required by tcolorbox[theorems]
-#   colortbl: provides \rowcolors, loaded by some dependency
 #   environ: required by tcolorbox
 #   etex-pkg: provides e-TeX, transitive dependency
-#   etoolbox: required by tcolorbox
 #   l3kernel: required by xparse
 #   l3packages: xparse
 #   ms: multitoc, ragged2e

--- a/bin/install-texlive
+++ b/bin/install-texlive
@@ -15,7 +15,6 @@ export PATH="/tmp/texlive/bin/x86_64-linux:${PATH}"
 tlmgr install dvips graphics graphics-def latex latex-bin latexmk
 
 # Package dependencies
-#   amsmath: required by tcolorbox[theorems]
 #   environ: required by tcolorbox
 #   etex-pkg: provides e-TeX, transitive dependency
 #   l3kernel: required by xparse
@@ -26,7 +25,6 @@ tlmgr install dvips graphics graphics-def latex latex-bin latexmk
 #   tools: array, calc, tabularx
 #   trimspaces: required by environ?
 tlmgr install \
-  amsmath \
   babel \
   colortbl \
   enumitem \

--- a/bin/install-texlive
+++ b/bin/install-texlive
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS='$\n\t'
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+tar -xf install-tl-unx.tar.gz
+cd install-tl-*
+./install-tl --profile="${DIR}/texlive.profile"
+
+export PATH="/tmp/texlive/bin/x86_64-linux:${PATH}"
+
+# Core packages
+tlmgr install dvips graphics graphics-def latex latex-bin latexmk
+
+# Package dependencies
+#   amsmath: required by tcolorbox[theorems]
+#   colortbl: provides \rowcolors, loaded by some dependency
+#   environ: required by tcolorbox
+#   etex-pkg: provides e-TeX, transitive dependency
+#   etoolbox: required by tcolorbox
+#   l3kernel: required by xparse
+#   l3packages: xparse
+#   ms: multitoc, ragged2e
+#   oberdiek: luacolor
+#   pgf: tikz
+#   tools: array, calc, tabularx
+#   trimspaces: required by environ?
+tlmgr install \
+  amsmath \
+  babel \
+  colortbl \
+  enumitem \
+  environ \
+  etex-pkg \
+  etoolbox \
+  fancyhdr \
+  fp \
+  geometry \
+  ifluatex \
+  ifxetex \
+  keycommand \
+  l3kernel \
+  l3packages \
+  microtype \
+  ms \
+  oberdiek \
+  pgf \
+  tcolorbox \
+  titlesec \
+  tocloft \
+  tools \
+  trimspaces \
+  xcolor \
+  xkeyval \
+  xstring
+
+# Fonts required by package or dependencies
+tlmgr install \
+  amsfonts \
+  bookman \
+  cm \
+  courier \
+  ec \
+  latex-fonts \
+  lm \
+  opensans \
+  psnfss
+
+# Document dependencies
+tlmgr install \
+  babel-english \
+  hang \
+  lipsum \
+  listings

--- a/bin/texlive.profile
+++ b/bin/texlive.profile
@@ -1,0 +1,10 @@
+selected_scheme scheme-infraonly
+TEXDIR /tmp/texlive
+TEXMFCONFIG ~/.texlive/texmf-config
+TEXMFHOME ~/texmf
+TEXMFLOCAL /tmp/texlive/texmf-local
+TEXMFSYSCONFIG /tmp/texlive/texmf-config
+TEXMFSYSVAR /tmp/texlive/texmf-var
+TEXMFVAR ~/.texlive/texmf-var
+option_doc 0
+option_src 0

--- a/dnd.sty
+++ b/dnd.sty
@@ -21,7 +21,7 @@
 \RequirePackage{ifluatex}
 \RequirePackage{keycommand}
 \RequirePackage{tabularx}
-\RequirePackage[most]{tcolorbox}  % used for some boxes
+\RequirePackage[breakable,skins,xparse]{tcolorbox}
 \RequirePackage{tikz}
 \RequirePackage{xkeyval}
 \RequirePackage{xparse}

--- a/dnd.sty
+++ b/dnd.sty
@@ -14,7 +14,9 @@
 
 \RequirePackage{array}
 \RequirePackage{calc}
+\RequirePackage{colortbl}
 \RequirePackage{enumitem}
+\RequirePackage{etoolbox}
 \RequirePackage{geometry}
 \RequirePackage{ifluatex}
 \RequirePackage{keycommand}


### PR DESCRIPTION
Configures Travis to build the example document under pdfTeX and LuaTeX.

Hooking up a CI service offers some interesting possibilities:

* Test if removing a dependency breaks the example document.
* Test if adding a new package significantly changes compilation time.
* Automatically upload PDFs and screenshot to GitHub with each release.

It also documents the minimal set of packages required to use the package.

You can view example builds here:

https://travis-ci.org/benwebber/DND-5e-LaTeX-Template