### PR TITLE
Helper commands for defining attacks and map areas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added boolean `layout` package option to control whether the package formats the document on load.
 * Added `nomultitoc` package option to toggle multi-column table of contents.
 * Added `dndbook` document class.
+* Added keycommands to generate text for melee, ranged, and hybrid (melee or ranged) attacks within monsterboxes. Includes localization support for the various phrases used.
+* Added commands to generate titled sections for map areas and sub-areas, with associated counters and automatic reference labelling (as `area:<title>`).
 
 ### Changed
 
@@ -19,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Removed excess space before and after `monsterbox`.
 * Challenge rating on `monsterbox` now only needs the CR number.
 * `monsterbox` renamed `monsterboxbg`. `monsterbox` is now an alias that maps to `monsterboxbg` or `monsterboxnobg`, depending on the value of the `bg` package option.
+* Title formats for sections now explicitly use `\RaggedRight` to avoid poor layout appearance when using justified output.
+* Prevents page breaks immediately following section/subsection/subsubsection titles.
 
 ### Fixed
 

--- a/example.tex
+++ b/example.tex
@@ -109,6 +109,60 @@
 	\begin{monsteraction}[More actions]
     See, here he goes again! Yet more text.
 	\end{monsteraction}
+	
+	\monstersection{Melee}
+	\begin{monsteraction}[Basic]
+	  \melee[mod=+2,dmg=\dice{1d6 + 1}]
+	\end{monsteraction}
+	\begin{monsteraction}[Alternate]
+	  \melee[
+	    mod=+2,
+	    dmg=\dice{1d6 + 1},
+	    ordmg=\dice{1d8 + 1},
+	    ordmgwhen=when wielded two-handed,
+	  ]
+	\end{monsteraction}
+	\begin{monsteraction}[Extra]
+	  \melee[
+	    mod=+2,
+	    dmg=\dice{1d6 + 1},
+	    plusdmg=\dice{2d8},
+	    plusdmgtype=fire,
+	  ]
+	\end{monsteraction}
+	
+	\monstersection{Ranged}
+	\begin{monsteraction}[Basic]
+	  \ranged[mod=+2,dmg=\dice{1d6 + 1},range=80/320 ft.]
+	\end{monsteraction}
+	\begin{monsteraction}[Alternate]
+	  \ranged[
+	    mod=+2,
+	    range=80/320 ft.,
+	    dmg=\dice{1d6 + 1},
+	    ordmg=\dice{1d8 + 1},
+	    ordmgwhen=when trying really hard,
+	  ]
+	\end{monsteraction}
+	\begin{monsteraction}[Extra]
+	  \ranged[
+	    mod=+2,
+	    range=80/320 ft.,
+	    dmg=\dice{1d6 + 1},
+	    plusdmg=\dice{2d8},
+	    plusdmgtype=fire,
+	  ]
+	\end{monsteraction}
+	
+	\monstersection{Melee or Ranged}
+	\begin{monsteraction}[Dagger]
+	  \meleeorranged[
+	    mod=+2,
+	    dmg=\dice{1d6+1},
+	    dmgtype=piercing,
+	    range=40/120 ft.,
+	  ]
+	\end{monsteraction}
 \end{monsterbox}
 
 \section{Spells}
@@ -236,6 +290,35 @@ See Table~\ref{tab:colors} for a list of accent colors that match the core books
   7           & Broken axe handle \\
   8           & Tarnished silver locket \\
 \end{dndtable}
+
+\newpage
+\section{Map Regions}
+
+\begin{lstlisting}
+  \area{Village of Hommlet}
+
+  This is the village of hommlet.
+
+  \subarea{Inn of the Welcome Wench}
+
+  Inside the village is the inn of the Welcome Wench.
+
+  \subarea{Blacksmith's Forge}
+
+  There's a blacksmith in town, too.
+\end{lstlisting}
+
+\area{Village of Hommlet}
+
+This is the village of hommlet.
+
+\subarea{Inn of the Welcome Wench}
+
+Inside the village is the inn of the Welcome Wench.
+
+\subarea{Blacksmith's Forge}
+
+There's a blacksmith in town, too.
 
 % End document
 \end{document}

--- a/example.tex
+++ b/example.tex
@@ -99,68 +99,50 @@
 	\begin{monsteraction}[Monster-super-powers]
 		This Monster has some serious superpowers!
 	\end{monsteraction}
-	\monstersection{Actions}
-	\begin{monsteraction}[Generate text]
-		This one can generate tremendous amounts of text! Though only when it wants to.
-	\end{monsteraction}
 
-	\begin{monsteraction}[More actions]
-    See, here he goes again! Yet more text.
-	\end{monsteraction}
-	
-	\monstersection{Melee}
-	\begin{monsteraction}[Basic]
-	  \melee[mod=+2,dmg=\dice{1d6 + 1}]
-	\end{monsteraction}
-	\begin{monsteraction}[Alternate]
-	  \melee[
-	    mod=+2,
-	    dmg=\dice{1d6 + 1},
-	    ordmg=\dice{1d8 + 1},
-	    ordmgwhen=when wielded two-handed,
-	  ]
-	\end{monsteraction}
-	\begin{monsteraction}[Extra]
-	  \melee[
-	    mod=+2,
-	    dmg=\dice{1d6 + 1},
-	    plusdmg=\dice{2d8},
-	    plusdmgtype=fire,
-	  ]
-	\end{monsteraction}
-	
-	\monstersection{Ranged}
-	\begin{monsteraction}[Basic]
-	  \ranged[mod=+2,dmg=\dice{1d6 + 1},range=80/320 ft.]
-	\end{monsteraction}
-	\begin{monsteraction}[Alternate]
-	  \ranged[
-	    mod=+2,
-	    range=80/320 ft.,
-	    dmg=\dice{1d6 + 1},
-	    ordmg=\dice{1d8 + 1},
-	    ordmgwhen=when trying really hard,
-	  ]
-	\end{monsteraction}
-	\begin{monsteraction}[Extra]
-	  \ranged[
-	    mod=+2,
-	    range=80/320 ft.,
-	    dmg=\dice{1d6 + 1},
-	    plusdmg=\dice{2d8},
-	    plusdmgtype=fire,
-	  ]
-	\end{monsteraction}
-	
-	\monstersection{Melee or Ranged}
-	\begin{monsteraction}[Dagger]
-	  \meleeorranged[
-	    mod=+2,
-	    dmg=\dice{1d6+1},
-	    dmgtype=piercing,
-	    range=40/120 ft.,
-	  ]
-	\end{monsteraction}
+	\monstersection{Actions}
+	\begin{monsteraction}[Multiattack]
+		The foo makes two melee attacks.
+  \end{monsteraction}
+
+  %Default values are shown commented out
+	\monsterattack[
+		%name=Dagger,
+		%enum* type={both,melee,ranged},
+		mod=+3,%mod=+0,
+		%reach=5,
+		%range=20/60,
+		%targets=one target,
+		dmg=\dice{1d4+1},%dmg=\dice{1d4},
+		%dmgtype=piercing,
+		%plusdmg=,
+		%plusdmgtype=,
+		%ordmg=,
+		%ordmgwhen=,
+		%extra=,
+	]
+
+  %\monstermelee calls \monsterattack with the melee option
+	\monstermelee[
+		name=Flame Tongue Longsword,
+		mod=+3,
+		dmg=\dice{1d8},
+		dmgtype=slashing,
+		ordmg=\dice{1d10},
+		ordmgwhen=if used with two hands,
+		plusdmg=\dice{2d6},
+		plusdmgtype=fire
+	]
+
+  %\monsterranged calls \monsterattack with the ranged option
+	\monsterranged[
+		name=Assassin's Light Crossbow,
+		mod=+0,
+		range=80/320,
+		dmg=\dice{1d8},
+		dmgtype=piercing,
+		extra={, and the target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one}
+	]
 \end{monsterbox}
 
 \section{Spells}
@@ -264,7 +246,6 @@ See Table~\ref{tab:colors} for a list of accent colors that match the core books
 \endgroup
 
 \subsubsection{Using element color arguments}
-
 \begin{lstlisting}
 \begin{dndtable}[cX][DmgCoral]
   \textbf{d8} & \textbf{Item} \\
@@ -289,34 +270,51 @@ See Table~\ref{tab:colors} for a list of accent colors that match the core books
   8           & Tarnished silver locket \\
 \end{dndtable}
 
-\newpage
 \section{Map Regions}
+The map region commands provide automatic numbering of areas.
 
+\noindent\begin{minipage}{\linewidth}
 \begin{lstlisting}
-  \area{Village of Hommlet}
-
-  This is the village of hommlet.
-
-  \subarea{Inn of the Welcome Wench}
-
-  Inside the village is the inn of the Welcome Wench.
-
-  \subarea{Blacksmith's Forge}
-
-  There's a blacksmith in town, too.
-\end{lstlisting}
-
 \area{Village of Hommlet}
-
 This is the village of hommlet.
 
 \subarea{Inn of the Welcome Wench}
+Inside the village is the inn of the
+Welcome Wench.
 
+\subarea{Blacksmith's Forge}
+There's a blacksmith in town, too.
+
+\area{Foo's Castle}
+This is foo's home, a hovel of mud and
+sticks.
+
+\subarea{Moat}
+This ditch has a board spanning it.
+
+\subarea{Entrance}
+A five-foot hole reveals the dirt floor
+illuminated by a hole in the roof.
+\end{lstlisting}
+\end{minipage}
+
+\area{Village of Hommlet}
+This is the village of hommlet.
+
+\subarea{Inn of the Welcome Wench}
 Inside the village is the inn of the Welcome Wench.
 
 \subarea{Blacksmith's Forge}
-
 There's a blacksmith in town, too.
+
+\area{Foo's Castle}
+This is foo's home, a hovel of mud and sticks.
+
+\subarea{Moat}
+This ditch has a board spanning it.
+
+\subarea{Entrance}
+A five-foot hole reveals the dirt floor illuminated by a hole in the roof.
 
 % End document
 \end{document}

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -59,103 +59,103 @@
 
 % Stat block made to look like stat blocks in the PHB.
 \newtcolorbox{monsterboxbg}[2][]{
-  enhanced,
-  frame hidden,
-  before skip=7pt plus 2pt,
-  boxrule=0pt,
-  breakable,
-  boxsep=0pt,
-  toptitle=11pt,
-  left=7pt,
-  right=7pt,
-  bottom=11pt,
-  arc=0mm,
-  oversize=0pt,
-  borderline north={4pt}{0pt}{titlered},
-  borderline north={2.5pt}{0.75pt}{statblockribbon},
-  borderline south={4pt}{0pt}{titlered},
-  borderline south={2.5pt}{0.75pt}{statblockribbon},
-  colback=statblockbg,
-  colbacktitle=statblockbg,
-  colframe=titlered,
-  fonttitle=\dnd@StatBlockTitleFont\Large,
-  coltitle=titlered,
-  fontupper=\dnd@StatBlockBodyFont,
-  fontlower=\dnd@StatBlockBodyFont,
-  title=#2,
-  #1
+	enhanced,
+	frame hidden,
+	before skip=7pt plus 2pt,
+	boxrule=0pt,
+	breakable,
+	boxsep=0pt,
+	toptitle=11pt,
+	left=7pt,
+	right=7pt,
+	bottom=11pt,
+	arc=0mm,
+	oversize=0pt,
+	borderline north={4pt}{0pt}{titlered},
+	borderline north={2.5pt}{0.75pt}{statblockribbon},
+	borderline south={4pt}{0pt}{titlered},
+	borderline south={2.5pt}{0.75pt}{statblockribbon},
+	colback=statblockbg,
+	colbacktitle=statblockbg,
+	colframe=titlered,
+	fonttitle=\dnd@StatBlockTitleFont\Large,
+	coltitle=titlered,
+	fontupper=\dnd@StatBlockBodyFont,
+	fontlower=\dnd@StatBlockBodyFont,
+	title=#2,
+	#1
 }
 
 \iftoggle{bool-bg}{
-  \let\monsterbox\monsterboxbg%
-  \let\endmonsterbox\endmonsterboxbg%
+	\let\monsterbox\monsterboxbg%
+	\let\endmonsterbox\endmonsterboxbg%
 }{
-  \let\monsterbox\monsterboxnobg%
-  \let\endmonsterbox\endmonsterboxnobg%
+	\let\monsterbox\monsterboxnobg%
+	\let\endmonsterbox\endmonsterboxnobg%
 }
 
 
 % Define Monster subsection header style
 \newcommand{\monstersection}[1]{%
-  \begingroup
-    \par\medskip\color{titlered}
-    \dnd@StatBlockSubtitleFont\large #1
-    % \rule is a horizontal command, so placing it under the title incurs extra
-    % line spacing. Use \hrule (a vertical command) instead.
-    \vspace{3pt}
-    \hrule height 0.6pt
-    \vspace{3pt}
-  \endgroup%
+	\begingroup
+		\par\medskip\color{titlered}
+		\dnd@StatBlockSubtitleFont\large #1
+		% \rule is a horizontal command, so placing it under the title incurs extra
+		% line spacing. Use \hrule (a vertical command) instead.
+		\vspace{3pt}
+		\hrule height 0.6pt
+		\vspace{3pt}
+	\endgroup%
 }
 
 \NewDocumentEnvironment{monsteraction}{o}{%
-  \IfValueTF{#1}{%
-    \smallskip\emph{\textbf{#1.}}%
-  }{\unskip}%
+	\IfValueTF{#1}{%
+		\smallskip\emph{\textbf{#1.}}%
+	}{\unskip}%
 }{\par}
 
 % A description variant used to list creature attributes.
 \newlist{dnd@monsterattrs}{description}{1}
 \setlist[dnd@monsterattrs]{
-    before=\color{titlered},
-    font=\dnd@StatBlockBodyFont\textbf,
-    labelsep=\widthof{ },
-    noitemsep,
-    nosep,
+		before=\color{titlered},
+		font=\dnd@StatBlockBodyFont\textbf,
+		labelsep=\widthof{ },
+		noitemsep,
+		nosep,
 }
 
 % A dnd@monsterattrs helper macro that always displays an attribute.
 \newcommand{\dnd@monsterattr}[2]{%
-  \item[#2] \commandkey{#1}
+	\item[#2] \commandkey{#1}
 }
 
 % A dnd@monsterattrs helper macro that displays an attribute if the user defined
 % it.
 \newcommand{\dnd@ifmonsterattr}[2]{%
-  \ifcommandkey{#1}{%
-    \item[#2] \commandkey{#1}
-  }{}%
+	\ifcommandkey{#1}{%
+		\item[#2] \commandkey{#1}
+	}{}%
 }
 
 %
 % Macros for use within the monster environment
 %
 \newkeycommand\basics[armorclass=0, hitpoints=0, speed=0]{%
-  \begin{dnd@monsterattrs}
-    \dnd@monsterattr{armorclass}{\armorclassname}
-    \dnd@monsterattr{hitpoints}{\hitpointsname}
-    \dnd@monsterattr{speed}{\speedname}
-  \end{dnd@monsterattrs}%
+	\begin{dnd@monsterattrs}
+		\dnd@monsterattr{armorclass}{\armorclassname}
+		\dnd@monsterattr{hitpoints}{\hitpointsname}
+		\dnd@monsterattr{speed}{\speedname}
+	\end{dnd@monsterattrs}%
 }
 
 % Taubular enviornment for stats-block
 \newkeycommand\stats[STR=\stat{10},
-                        DEX=\stat{10},
-                        CON=\stat{10},
-                        INT=\stat{10},
-                        WIS=\stat{10},
-                        CHA=\stat{10}]{%
-    \begingroup
+												DEX=\stat{10},
+												CON=\stat{10},
+												INT=\stat{10},
+												WIS=\stat{10},
+												CHA=\stat{10}]{%
+		\begingroup
 		\small\centering\color{titlered}
 		\resizebox{\linewidth}{\height}{%
 			\begin{tabular}{cccccc}
@@ -165,103 +165,135 @@
 			\end{tabular}
 		}%
 		\\[0.4em] %adds space after table
-    \endgroup
+		\endgroup
 }
 
 \newkeycommand\details[
-  skills=,
-  damageimmunities=,
-  savingthrows=,
-  conditionimmunities=,
-  damageresistances=,
-  damagevulnerabilities=,
-  senses=---,
-  languages=---,
-  challenge=1,
-  ]{%
-  \begin{dnd@monsterattrs}
-    \dnd@ifmonsterattr{savingthrows}{\savesname}
-    \dnd@ifmonsterattr{skills}{\skillsname}
-    \dnd@ifmonsterattr{damagevulnerabilities}{\dvulname}
-    \dnd@ifmonsterattr{damageresistances}{\dresname}
-    \dnd@ifmonsterattr{damageimmunities}{\dimmname}
-    \dnd@ifmonsterattr{conditionimmunities}{\cimmname}
-    \dnd@monsterattr{senses}{\sensesname}
-    \dnd@monsterattr{languages}{\languagesname}
-    \item[\challengename] \crexp{\commandkey{challenge}}
-  \end{dnd@monsterattrs}%
+	skills=,
+	damageimmunities=,
+	savingthrows=,
+	conditionimmunities=,
+	damageresistances=,
+	damagevulnerabilities=,
+	senses=---,
+	languages=---,
+	challenge=1,
+	]{%
+	\begin{dnd@monsterattrs}
+		\dnd@ifmonsterattr{savingthrows}{\savesname}
+		\dnd@ifmonsterattr{skills}{\skillsname}
+		\dnd@ifmonsterattr{damagevulnerabilities}{\dvulname}
+		\dnd@ifmonsterattr{damageresistances}{\dresname}
+		\dnd@ifmonsterattr{damageimmunities}{\dimmname}
+		\dnd@ifmonsterattr{conditionimmunities}{\cimmname}
+		\dnd@monsterattr{senses}{\sensesname}
+		\dnd@monsterattr{languages}{\languagesname}
+		\item[\challengename] \crexp{\commandkey{challenge}}
+	\end{dnd@monsterattrs}%
 }
 
 \newcommand{\dnd@hit}[1]{%
-  \commandkey{#1}\ \tohitname%
+	\commandkey{#1}\ \tohitname%
 }
 \newcommand{\dnd@damage}[2]{%
-  \commandkey{#1}\ \commandkey{#2}\ \damagename%
+	\commandkey{#1}\ \commandkey{#2}\ \damagename%
 }
 
 \newcommand{\dnd@ifplusdmg}[2]{%
-  \ifcommandkey{#1}{%
-    , plus \commandkey{#1}\ \commandkey{#2}\ \damagename%
-  }{}%
+	\ifcommandkey{#1}{%
+		{ }plus \commandkey{#1}\ \commandkey{#2}\ \damagename%
+	}{}%
 }
-\newcommand{\dnd@ifordmg}[3]{%
-  \ifcommandkey{#1}{%
-    , or \commandkey{#1}\ \commandkey{#2}\ \damagename\ \commandkey{#3}%
-  }{}%
+\newcommand{\dnd@ifordmg}[5]{%
+	\ifcommandkey{#1}{%
+		, or \commandkey{#1}\ \commandkey{#2}\ \damagename\dnd@ifplusdmg{#4}{#5}\ \commandkey{#3}%
+	}{}%
 }
 
-\newkeycommand\melee[
-    mod=+0,
-    reach=5 ft.,
-    targets=one target,
-    dmg=\dice{1d6},
-    dmgtype=slashing,
-    plusdmg=,
-    plusdmgtype=,
-    ordmg=,
-    ordmgtype=,
-    ordmgwhen=,
-  ]{%
-  \textit{\meleeattackname:} \dnd@hit{mod},
-  \reachname\ \commandkey{reach},
-  \commandkey{targets}.
-  \textit{\hitname:} \dnd@damage{dmg}{dmgtype}\dnd@ifordmg{ordmg}{ordmgtype}{ordmgwhen}\dnd@ifplusdmg{plusdmg}{plusdmgtype}.
+\newkeycommand+[\|]\monstermelee[
+		name=Club,
+		mod=+0,
+		reach=5,
+		targets=one target,
+		dmg=\dice{1d4},
+		dmgtype=bludgeoning,
+		plusdmg=,
+		plusdmgtype=,
+		ordmg=,
+		ordmgwhen=,
+		extra=,
+	]{%
+	|\monsterattack|[
+		name={\commandkey{name}},
+		type=melee,
+		mod={\commandkey{mod}},
+		reach={\commandkey{reach}},
+		targets={\commandkey{targets}},
+		dmg={\commandkey{dmg}},
+		dmgtype={\commandkey{dmgtype}},
+		plusdmg={\commandkey{plusdmg}},
+		plusdmgtype={\commandkey{plusdmgtype}},
+		ordmg={\commandkey{ordmg}},
+		ordmgwhen={\commandkey{ordmgwhen}},
+		extra={\commandkey{extra}},
+	]
 }
-\newkeycommand\ranged[
-    mod=+0,
-    range=30 ft.,
-    targets=one target,
-    dmg=\dice{1d6},
-    dmgtype=piercing,
-    plusdmg=,
-    plusdmgtype=,
-    ordmg=,
-    ordmgtype=,
-    ordmgwhen=,
-  ]{%
-  \textit{\rangedattackname:} \dnd@hit{mod},
-  \rangename\ \commandkey{range},
-  \commandkey{targets}.
-  \textit{\hitname:} \dnd@damage{dmg}{dmgtype}\dnd@ifplusdmg{plusdmg}{plusdmgtype}\dnd@ifordmg{ordmg}{ordmgtype}{ordmgwhen}.
+\newkeycommand+[\|]\monsterranged[
+		name=Shortbow,
+		mod=+0,
+		range=80/320,
+		targets=one target,
+		dmg=\dice{1d6},
+		dmgtype=piercing,
+		plusdmg=,
+		plusdmgtype=,
+		ordmg=,
+		ordmgwhen=,
+		extra=,
+	]{%
+	|\monsterattack|[
+		name={\commandkey{name}},
+		type=ranged,
+		mod={\commandkey{mod}},
+		range={\commandkey{range}},
+		targets={\commandkey{targets}},
+		dmg={\commandkey{dmg}},
+		dmgtype={\commandkey{dmgtype}},
+		plusdmg={\commandkey{plusdmg}},
+		plusdmgtype={\commandkey{plusdmgtype}},
+		ordmg={\commandkey{ordmg}},
+		ordmgwhen={\commandkey{ordmgwhen}},
+		extra={\commandkey{extra}},
+	]
 }
-\newkeycommand\meleeorranged[
-    mod=+0,
-    reach=5 ft.,
-    range=30 ft.,
-    targets=one target,
-    dmg=\dice{1d6},
-    dmgtype=piercing,
-    plusdmg=,
-    plusdmgtype=,
-    ordmg=,
-    ordmgtype=,
-    ordmgwhen=,
-    extra=,
-  ]{%
-  \textit{\meleeorrangedattackname:} \dnd@hit{mod},
-  \reachname\ \commandkey{reach} or \rangename\ \commandkey{range},
-  \commandkey{targets}.
-  \textit{\hitname:} \dnd@damage{dmg}{dmgtype}\dnd@ifplusdmg{plusdmg}{plusdmgtype}\dnd@ifordmg{ordmg}{ordmgtype}{ordmgwhen}\ifcommandkey{extra}{ \commandkey{extra}}{}.
+
+\newkeycommand\monsterattack[
+		name=Dagger,
+		enum* type={both,melee,ranged},
+		mod=+0,
+		reach=5,
+		range=20/60,
+		targets=one target,
+		dmg=\dice{1d4},
+		dmgtype=piercing,
+		plusdmg=,
+		plusdmgtype=,
+		ordmg=,
+		ordmgwhen=,
+		extra=,
+	]{%
+	\begin{monsteraction}[\commandkey{name}]
+		\IfStrEqCase{\commandkey{type}}{%
+			{melee}{\textit{\meleeattackname:} \dnd@hit{mod}, \reachname\ \commandkey{reach} \ftname}%
+			{ranged}{\textit{\rangedattackname:} \dnd@hit{mod}, \rangename\ \commandkey{range} \ftname}%
+			{both}{\textit{\meleeorrangedattackname:} \dnd@hit{mod}, \reachname\ \commandkey{reach} \ftname or \rangename\ \commandkey{range} \ftname}%
+		}[]%
+		, \commandkey{targets}.
+		\textit{\hitname:} \dnd@damage{dmg}{dmgtype}%
+		\dnd@ifplusdmg{plusdmg}{plusdmgtype}%
+		\dnd@ifordmg{ordmg}{dmgtype}{ordmgwhen}{plusdmg}{plusdmgtype}%
+		\ifcommandkey{extra}{\commandkey{extra}}{}.
+	\end{monsteraction}
 }
 
 \newcommand\crexp[1]{%

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -190,6 +190,78 @@
   \end{dnd@monsterattrs}%
 }
 
+\newcommand{\dnd@hit}[1]{%
+  \commandkey{#1}\ \tohitname%
+}
+\newcommand{\dnd@damage}[2]{%
+  \commandkey{#1}\ \commandkey{#2}\ \damagename%
+}
+
+\newcommand{\dnd@ifplusdmg}[2]{%
+  \ifcommandkey{#1}{%
+    , plus \commandkey{#1}\ \commandkey{#2}\ \damagename%
+  }{}%
+}
+\newcommand{\dnd@ifordmg}[3]{%
+  \ifcommandkey{#1}{%
+    , or \commandkey{#1}\ \commandkey{#2}\ \damagename\ \commandkey{#3}%
+  }{}%
+}
+
+\newkeycommand\melee[
+    mod=+0,
+    reach=5 ft.,
+    targets=one target,
+    dmg=\dice{1d6},
+    dmgtype=slashing,
+    plusdmg=,
+    plusdmgtype=,
+    ordmg=,
+    ordmgtype=,
+    ordmgwhen=,
+  ]{%
+  \textit{\meleeattackname:} \dnd@hit{mod},
+  \reachname\ \commandkey{reach},
+  \commandkey{targets}.
+  \textit{\hitname:} \dnd@damage{dmg}{dmgtype}\dnd@ifordmg{ordmg}{ordmgtype}{ordmgwhen}\dnd@ifplusdmg{plusdmg}{plusdmgtype}.
+}
+\newkeycommand\ranged[
+    mod=+0,
+    range=30 ft.,
+    targets=one target,
+    dmg=\dice{1d6},
+    dmgtype=piercing,
+    plusdmg=,
+    plusdmgtype=,
+    ordmg=,
+    ordmgtype=,
+    ordmgwhen=,
+  ]{%
+  \textit{\rangedattackname:} \dnd@hit{mod},
+  \rangename\ \commandkey{range},
+  \commandkey{targets}.
+  \textit{\hitname:} \dnd@damage{dmg}{dmgtype}\dnd@ifplusdmg{plusdmg}{plusdmgtype}\dnd@ifordmg{ordmg}{ordmgtype}{ordmgwhen}.
+}
+\newkeycommand\meleeorranged[
+    mod=+0,
+    reach=5 ft.,
+    range=30 ft.,
+    targets=one target,
+    dmg=\dice{1d6},
+    dmgtype=piercing,
+    plusdmg=,
+    plusdmgtype=,
+    ordmg=,
+    ordmgtype=,
+    ordmgwhen=,
+    extra=,
+  ]{%
+  \textit{\meleeorrangedattackname:} \dnd@hit{mod},
+  \reachname\ \commandkey{reach} or \rangename\ \commandkey{range},
+  \commandkey{targets}.
+  \textit{\hitname:} \dnd@damage{dmg}{dmgtype}\dnd@ifplusdmg{plusdmg}{plusdmgtype}\dnd@ifordmg{ordmg}{ordmgtype}{ordmgwhen}\ifcommandkey{extra}{ \commandkey{extra}}{}.
+}
+
 \newcommand\crexp[1]{%
 	\IfStrEqCase{#1}{%
 		{0}{#1 (0 XP)}%

--- a/lib/dndsections.sty
+++ b/lib/dndsections.sty
@@ -18,16 +18,16 @@
 
 % Section
 \titleformat{\section}
-{\color{titlered}\dnd@TitleFont\LARGE}{\thesection\quad}{0pt}{}
+{\color{titlered}\dnd@TitleFont\LARGE\RaggedRight}{\thesection\quad}{0pt}{\nopagebreak}
 
 % Subsection
 \titleformat{\subsection}
-{\color{titlered}\dnd@TitleFont\Large}{\thesubsection\quad}{0pt}{}
+{\color{titlered}\dnd@TitleFont\Large\RaggedRight}{\thesubsection\quad}{0pt}{\nopagebreak}
 [\titleline{\color{titlegold}\titlerule[1pt]}]
 
 % Subsubsection
 \titleformat{\subsubsection}
-{\color{titlered}\dnd@TitleFont\large}{\thesubsubsection\quad}{0pt}{}[]
+{\color{titlered}\dnd@TitleFont\large\RaggedRight}{\thesubsubsection\quad}{0pt}{\nopagebreak}[]
 
 % Paragraph
 \titleformat{\paragraph}[runin]
@@ -46,3 +46,26 @@
 	\subsubsection{#1}\vspace{-1ex}
 	\textit{#2}\vspace{1ex}\par
 	} 
+
+% Areas
+\newcounter{Area}
+\newcommand{\area}[1]{%
+  \refstepcounter{Area}\label{area:#1}
+  \subsection{\arabic{Area}. #1}
+}
+
+% defines sub-areas, like '5a', '5b'
+\newcounter{SubArea}[Area]
+\newcommand{\subarea}[1]{%
+  \refstepcounter{SubArea}\label{area:#1}
+  \subsubsection{\arabic{Area}\alph{SubArea}. #1}
+}
+
+% sub area references should be '5a', '5b', not '1', '2'
+\renewcommand\p@SubArea{\arabic{Area}}
+\renewcommand\theSubArea{\alph{SubArea}}
+
+\newcounter{DetailArea}[subsection]
+\newcommand{\DetailArea@Prefix}{}
+\newcommand{\SetDetailAreaPrefix}[1]{\renewcommand{\DetailArea@Prefix}
+      {#1--\arabic{DetailArea}\par\expandafter\ignorespaces\noindent}}

--- a/lib/dndstrings.sty
+++ b/lib/dndstrings.sty
@@ -21,6 +21,7 @@
 \newcommand\languagesname{Languages}
 \newcommand\challengename{Challenge}
 
+\newcommand\ftname{ft.}
 \newcommand\meleeattackname{Melee Weapon Attack}
 \newcommand\rangedattackname{Ranged Weapon Attack}
 \newcommand\meleeorrangedattackname{Melee or Ranged Weapon Attack}

--- a/lib/dndstrings.sty
+++ b/lib/dndstrings.sty
@@ -21,6 +21,14 @@
 \newcommand\languagesname{Languages}
 \newcommand\challengename{Challenge}
 
+\newcommand\meleeattackname{Melee Weapon Attack}
+\newcommand\rangedattackname{Ranged Weapon Attack}
+\newcommand\meleeorrangedattackname{Melee or Ranged Weapon Attack}
+\newcommand\tohitname{to hit}
+\newcommand\reachname{reach}
+\newcommand\rangename{range}
+\newcommand\hitname{Hit}
+\newcommand\damagename{damage}
 
 % Check if either babel or polyglossia have been loaded,
 % in which case load the string captions


### PR DESCRIPTION
New features:

- `\melee`, `\ranged`, and `\meleeorranged` commands to quickly define attacks in monster entries, with language support.
- `\area` and `\subarea` commands with associated counters and labels to generate automatically-numbered sections/subsections for your map references.
- Updated `example.tex` to showcase new features.

Modifications:

- Title formats for `\section`, `\subsection`, and `\subsubsection` explicitly use `\RaggedRight` now, since they frequently look pants in these narrow columns when justification is used.
- Prevent page breaks immediately following section/subsection titles.