### PR TITLE
Separate table option from xcolor to avoid option clashes

### DIFF
--- a/dnd.sty
+++ b/dnd.sty
@@ -11,7 +11,6 @@
 
 \PassOptionsToPackage{table}{xcolor} % Helps prevent option clash with other packages that include xcolor
 
-\RequirePackage{xcolor}
 \RequirePackage{array}
 \RequirePackage{calc}
 \RequirePackage{colortbl}
@@ -23,6 +22,7 @@
 \RequirePackage{tabularx}
 \RequirePackage[breakable,skins,xparse]{tcolorbox}
 \RequirePackage{tikz}
+\RequirePackage{xcolor}
 \RequirePackage{xkeyval}
 \RequirePackage{xparse}
 

--- a/dnd.sty
+++ b/dnd.sty
@@ -9,9 +9,9 @@
 % Prerequisite Packages
 %
 
-% Loaded before tikz to avoid package option conflict with pgf.
-\RequirePackage[table]{xcolor}
+\PassOptionsToPackage{table}{xcolor} % Helps prevent option clash with other packages that include xcolor
 
+\RequirePackage{xcolor}
 \RequirePackage{array}
 \RequirePackage{calc}
 \RequirePackage{colortbl}


### PR DESCRIPTION
Separate table option from xcolor to avoid option clashes from user-included packages that use xcolor.