### PR TITLE
Labelling helpers for `\area` and `\subarea`

### DIFF
--- a/lib/dndsections.sty
+++ b/lib/dndsections.sty
@@ -2,6 +2,7 @@
 
 \RequirePackage[titles]{tocloft}
 \RequirePackage{titlesec}	% Used to adjust (sub)section formatting
+\RequirePackage{xparse}     % for LaTeX3 \NewDocumentCommand
 
 \iftoggle{multitoc}{%
   \RequirePackage[toc]{multitoc}
@@ -53,18 +54,36 @@
 	\textit{#2}\vspace{1ex}\par
 	} 
 
-% Areas
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Map Areas and their References
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% Labelling helpers
+\newcommand{\AreaLabel@Prefix}{area}
+\newcommand{\SetAreaLabelPrefix}[1]{%
+  \renewcommand{\AreaLabel@Prefix}{#1}}
+
 \newcounter{Area}
-\newcommand{\area}[1]{%
-  \refstepcounter{Area}\label{area:#1}
-  \subsection{\arabic{Area}. #1}
+\newcommand\ResetAreas{%
+  \setcounter{Area}{0}}
+
+\NewDocumentCommand\area{mo}{%
+  \refstepcounter{Area}%
+  \IfNoValueTF{#2}%
+    {\label{\AreaLabel@Prefix:#1}}%
+    {\label{\AreaLabel@Prefix:#2}}%
+  \subsection{\arabic{Area}. #1}%
 }
 
 % defines sub-areas, like '5a', '5b'
 \newcounter{SubArea}[Area]
-\newcommand{\subarea}[1]{%
-  \refstepcounter{SubArea}\label{area:#1}
-  \subsubsection{\arabic{Area}\alph{SubArea}. #1}
+
+\NewDocumentCommand\subarea{mo}{%
+  \refstepcounter{SubArea}%
+  \IfNoValueTF{#2}%
+    {\label{\AreaLabel@Prefix:#1}}%
+    {\label{\AreaLabel@Prefix:#2}}%
+  \subsubsection{\arabic{Area}\alph{SubArea}. #1}%
 }
 
 % sub area references should be '5a', '5b', not '1', '2'


### PR DESCRIPTION
This adds new commands allowing you to modify the labels attached to areas and subareas. Specifically, you can now use `\SetAreaPrefix` and `\SetSubAreaPrefix` to specify a prefix for each new area or sub-area. The label will be of the form (`<prefix>:<area name>`), in this case, though there's now a second, optional, parameter which allows you to override the `<area name>` part. The `\subarea` command provides similar options.

I've also added a `\ResetAreas` command, which resets the `Area` counter.

It works like this now:

```latex
\SetAreaPrefix{area:hommlet}
\area{Village Green} % creates \label{area:hommlet:Village Green}
\area{Blacksmith's House}[blacksmith] % creates \label{area:hommlet:blacksmith}
```