### PR TITLE
Fix XP for challenge rating 30

### DIFF
--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -332,6 +332,6 @@
 		{27}{#1 (\numprint{105000} \xpname)}%
 		{28}{#1 (\numprint{120000} \xpname)}%
 		{29}{#1 (\numprint{135000} \xpname)}%
-		{30}{#1 (\numprint{1155000} \xpname)}%
+		{30}{#1 (\numprint{155000} \xpname)}%
 	}[#1]%
 }


### PR DESCRIPTION
Just a typo.

See: 2882b69b43 (Added localization to challenge rating/XP generation. (#150))