### PR TITLE
Spanish translation fixes

### DIFF
--- a/lib/languages/spanish.sty
+++ b/lib/languages/spanish.sty
@@ -21,16 +21,19 @@
     \renewcommand\cimmname{Inmunidades~a~condición}
     \renewcommand\savesname{Tiradas~de~salvación}
     \renewcommand\sensesname{Sentidos}
+    \renewcommand\defaultsensesname{Percepción~pasiva~10}
     \renewcommand\languagesname{Idiomas}
     \renewcommand\challengename{Desafío}
     \renewcommand\xpname{PE}
     % Monster attack
     \renewcommand\unitsname{pies}
-    \renewcommand\meleeattackname{Ataque~de~arma~cuerpo~a~cuerpo}
-    \renewcommand\rangedattackname{Ataque~de~arma~a~distancia}
-    \renewcommand\meleeorrangedattackname{Ataque~de~arma~cuerpo~a~cuerpo~o~a~distancia}
+    \renewcommand\weaponname{Arma}
+    \renewcommand\spellname{Hechizo}
+    \renewcommand\meleeattackname{Ataque~|1|~cuerpo~a~cuerpo}
+    \renewcommand\rangedattackname{Ataque~|1|~a~distancia}
+    \renewcommand\meleeorrangedattackname{Ataque~|1|~cuerpo~a~cuerpo~o~a~distancia}
     \renewcommand\orname{o}
-    \renewcommand\tohitname{para~golpear}
+    \renewcommand\tohitname{|1|~para~golpear}
     \renewcommand\defaulttargetsname{un~objetivo}
     \renewcommand\reachname{alcance}
     \renewcommand\rangename{alcance}
@@ -65,6 +68,5 @@
     \renewcommand\spelldurationname{Duración}
     % Miscellaneous
     \renewcommand\dname{d}
-%    \renewcommand\pageabbreviationname{pg.}
+    \renewcommand\pageabbreviationname{pág.}
   }
-

--- a/lib/languages/spanish.sty
+++ b/lib/languages/spanish.sty
@@ -15,10 +15,10 @@
     \renewcommand\chastatname{CAR}
     % Monster details
     \renewcommand\skillsname{Habilidades}
-    \renewcommand\dimmname{Inmunidades~al~daño}
-    \renewcommand\dvulname{Vulnerabilidades~al~daño}
-    \renewcommand\dresname{Resistencias~al~daño}
-    \renewcommand\cimmname{Inmunidades~a~condición}
+    \renewcommand\dimmname{Inmunidad~a~daño}
+    \renewcommand\dvulname{Vulnerabilidad~a~daño}
+    \renewcommand\dresname{Resistencia~a~daño}
+    \renewcommand\cimmname{Inmunidad~a~estados}
     \renewcommand\savesname{Tiradas~de~salvación}
     \renewcommand\sensesname{Sentidos}
     \renewcommand\defaultsensesname{Percepción~pasiva~10}
@@ -27,13 +27,13 @@
     \renewcommand\xpname{PE}
     % Monster attack
     \renewcommand\unitsname{pies}
-    \renewcommand\weaponname{Arma}
+    \renewcommand\weaponname{arma}
     \renewcommand\spellname{Hechizo}
-    \renewcommand\meleeattackname{Ataque~|1|~cuerpo~a~cuerpo}
-    \renewcommand\rangedattackname{Ataque~|1|~a~distancia}
-    \renewcommand\meleeorrangedattackname{Ataque~|1|~cuerpo~a~cuerpo~o~a~distancia}
+    \renewcommand\meleeattackname{Ataque~con~|1|~cuerpo~a~cuerpo}
+    \renewcommand\rangedattackname{Ataque~con~|1|~a~distancia}
+    \renewcommand\meleeorrangedattackname{Ataque~con~|1|~cuerpo~a~cuerpo~o~a~distancia}
     \renewcommand\orname{o}
-    \renewcommand\tohitname{|1|~para~golpear}
+    \renewcommand\tohitname{|1|~a~impactar}
     \renewcommand\defaulttargetsname{un~objetivo}
     \renewcommand\reachname{alcance}
     \renewcommand\rangename{alcance}

--- a/lib/languages/spanish.sty
+++ b/lib/languages/spanish.sty
@@ -69,4 +69,5 @@
     % Miscellaneous
     \renewcommand\dname{d}
     \renewcommand\pageabbreviationname{pág.}
+    \renewcommand\tocchapterabbreviationname{cap.}
   }

--- a/lib/languages/spanish.sty
+++ b/lib/languages/spanish.sty
@@ -39,7 +39,7 @@
     \renewcommand\rangename{alcance}
     \renewcommand\hitname{Impacto}
     \renewcommand\damagename{daño}
-    \renewcommand\plusname{+}
+    \renewcommand\plusname{y}
     % Spell levels
     \renewcommand\spellcantripsname{Trucos}
     \renewcommand\spellfirstlevelname{Nivel~1}


### PR DESCRIPTION
The spanish translation is missing some parameters when overwriting the template's commands. I added them and reworded them slightly, to make them read nicer and look closer to the italian and english versions.

For example, `Ataque de arma cuerpo a cuerpo` now is `Ataque +X cuerpo a cuerpo`.

I also added some commands that were missing, like `Weapon` > `Arma`.