### PR TITLE
Spanish translation and footer fixes

### DIFF
--- a/lib/dndheader.sty
+++ b/lib/dndheader.sty
@@ -19,7 +19,7 @@
             \MakeUppercase
               {
                 \ifnum\value{secnumdepth}>-1
-                  \chaptername\ \thechapter :~
+                  \chaptertitlename\ \thechapter :~
                 \fi
                 #1
               }

--- a/lib/languages/spanish.sty
+++ b/lib/languages/spanish.sty
@@ -15,28 +15,31 @@
     \renewcommand\chastatname{CAR}
     % Monster details
     \renewcommand\skillsname{Habilidades}
-    \renewcommand\dimmname{Inmunidades~al~daño}
-    \renewcommand\dvulname{Vulnerabilidades~al~daño}
-    \renewcommand\dresname{Resistencias~al~daño}
-    \renewcommand\cimmname{Inmunidades~a~condición}
+    \renewcommand\dimmname{Inmunidad~a~daño}
+    \renewcommand\dvulname{Vulnerabilidad~a~daño}
+    \renewcommand\dresname{Resistencia~a~daño}
+    \renewcommand\cimmname{Inmunidad~a~estados}
     \renewcommand\savesname{Tiradas~de~salvación}
     \renewcommand\sensesname{Sentidos}
+    \renewcommand\defaultsensesname{Percepción~pasiva~10}
     \renewcommand\languagesname{Idiomas}
     \renewcommand\challengename{Desafío}
     \renewcommand\xpname{PE}
     % Monster attack
     \renewcommand\unitsname{pies}
-    \renewcommand\meleeattackname{Ataque~de~arma~cuerpo~a~cuerpo}
-    \renewcommand\rangedattackname{Ataque~de~arma~a~distancia}
-    \renewcommand\meleeorrangedattackname{Ataque~de~arma~cuerpo~a~cuerpo~o~a~distancia}
+    \renewcommand\weaponname{arma}
+    \renewcommand\spellname{Hechizo}
+    \renewcommand\meleeattackname{Ataque~con~|1|~cuerpo~a~cuerpo}
+    \renewcommand\rangedattackname{Ataque~con~|1|~a~distancia}
+    \renewcommand\meleeorrangedattackname{Ataque~con~|1|~cuerpo~a~cuerpo~o~a~distancia}
     \renewcommand\orname{o}
-    \renewcommand\tohitname{para~golpear}
+    \renewcommand\tohitname{|1|~a~impactar}
     \renewcommand\defaulttargetsname{un~objetivo}
     \renewcommand\reachname{alcance}
     \renewcommand\rangename{alcance}
     \renewcommand\hitname{Impacto}
     \renewcommand\damagename{daño}
-    \renewcommand\plusname{+}
+    \renewcommand\plusname{y}
     % Spell levels
     \renewcommand\spellcantripsname{Trucos}
     \renewcommand\spellfirstlevelname{Nivel~1}
@@ -65,6 +68,6 @@
     \renewcommand\spelldurationname{Duración}
     % Miscellaneous
     \renewcommand\dname{d}
-%    \renewcommand\pageabbreviationname{pg.}
+    \renewcommand\pageabbreviationname{pág.}
+    \renewcommand\tocchapterabbreviationname{cap.}
   }
-


### PR DESCRIPTION
Bring fixes to 0.8 to main development branch.

- Spanish translation fixes (#289)
- Replace \chaptername with \chaptertitlename (#291)