### PR TITLE
Japanese update

### DIFF
--- a/lib/languages/_template.sty
+++ b/lib/languages/_template.sty
@@ -67,6 +67,7 @@
     \renewcommand\spellcomponentsname{Components}
     \renewcommand\spelldurationname{Duration}
     % Miscellaneous
+    \renewcommand\tocchapterabbreviationname{Ch.}
     \renewcommand\pageabbreviationname{pg.}
     \renewcommand\dname{d}
   }

--- a/lib/languages/_template.sty
+++ b/lib/languages/_template.sty
@@ -61,12 +61,12 @@
     \renewcommand\innateatwillname{At~will}
     \renewcommand\numberperdayname{|1|/day}
     \renewcommand\numberperdayeachname{|1|/day~each}
-%    % Spell header
+    % Spell header
     \renewcommand\spellcastingtimename{Casting~Time}
     \renewcommand\spellrangename{Range}
     \renewcommand\spellcomponentsname{Components}
     \renewcommand\spelldurationname{Duration}
-%    % Miscellaneous
+    % Miscellaneous
     \renewcommand\pageabbreviationname{pg.}
     \renewcommand\dname{d}
   }

--- a/lib/languages/japanese.sty
+++ b/lib/languages/japanese.sty
@@ -59,13 +59,13 @@
     % Innate spellcasting
     \renewcommand\innateatwillname{無限回}
     \renewcommand\numberperdayname{|1|回／日}
-    \renewcommand\numberperdayeachname{|1|回／日ずつ} % TODO: Confirm official translation
+    \renewcommand\numberperdayeachname{各|1|回／日}
     % Spell header
     \renewcommand\spellcastingtimename{発動時間}
     \renewcommand\spellrangename{射程}
     \renewcommand\spellcomponentsname{構成要素}
     \renewcommand\spelldurationname{持続時間}
     % Miscellaneous
+    \renewcommand\pageabbreviationname{pg.}
     \renewcommand\dname{d}
-%    \newcommand\tocchapterabbreviationname{Ch.}
   }

--- a/lib/languages/japanese.sty
+++ b/lib/languages/japanese.sty
@@ -22,6 +22,7 @@
     \renewcommand\cimmname{状態完全耐性：}
     \renewcommand\savesname{セーブ：}
     \renewcommand\sensesname{感覚：}
+    \renewcommand\defaultsensesname{受動〈知覚〉10}
     \renewcommand\languagesname{言語：}
     \renewcommand\challengename{脅威度：}
     \renewcommand\xpname{XP}

--- a/lib/languages/japanese.sty
+++ b/lib/languages/japanese.sty
@@ -66,6 +66,7 @@
     \renewcommand\spellcomponentsname{構成要素}
     \renewcommand\spelldurationname{持続時間}
     % Miscellaneous
-    \renewcommand\pageabbreviationname{pg.}
+    \renewcommand\tocchapterabbreviationname{章} % TODO: Update to 第|1|章 when https://github.com/rpgtex/DND-5e-LaTeX-Template/issues/308 is closed
+    \renewcommand\pageabbreviationname{ページ} % TODO: Update to |1|ページ when https://github.com/rpgtex/DND-5e-LaTeX-Template/issues/308 is closed
     \renewcommand\dname{d}
   }


### PR DESCRIPTION
Following-up on #304.

This improves on #213.

The translation for `\defaultsensesname` can be found on page 10 of the [free Japanese Basic Rules](http://hobbyjapan.co.jp/dd/support/pdf/dnd_dm_br_ver2.pdf):

![Screenshot_2021-01-24 dnd_dm_br_ver2 pdf](https://user-images.githubusercontent.com/23304955/105632623-7d49e700-5e97-11eb-8915-14dc6f887643.png)

I fixed the translation for `\numberperdayeachname` according to the Japanese Monster Manual (see the last line):
![2021-01-24-0001 (Small)](https://user-images.githubusercontent.com/23304955/105632670-bc783800-5e97-11eb-84d9-c27b28bf80d2.jpg)


Also, I found an issue regarding colons in some translations like `\meleeorrangedattackname`. The translation includes the Japanese colon (：) but the template already adds a standard colon: 

![colon](https://user-images.githubusercontent.com/23304955/105632792-78396780-5e98-11eb-9947-15c08f805fab.png)

Some other translations like `\innateatwillname` or `\numberperdayname` use the standard colon instead of the Japanese one:
![colon2](https://user-images.githubusercontent.com/23304955/105632834-a28b2500-5e98-11eb-8805-916521de7171.png)

I think this is related to #212, i.e. colons should be moved from the template to all translation files. Since this concerns other translations I wanted some opinion before including it in this PR.

For reference, here is [the example PDF compiled in Japanese](https://github.com/rpgtex/DND-5e-LaTeX-Template/files/5862391/example-japanese.pdf).
