### PR TITLE
Add new command that switches between chapter abbreviation and Appendix, use it in toc

### DIFF
--- a/lib/dndtoc.sty
+++ b/lib/dndtoc.sty
@@ -18,7 +18,7 @@
   \titlecontents{chapter}
     [0pt] % left
     { \addvspace{.1in} \DndFontTocChapter } % above-code
-    {\tocchapterabbreviationname\ \thecontentslabel :~ } % numbered-entry-format
+    { \tocchapapp\ \thecontentslabel :~ } % numbered-entry-format
     {} % numberless-entry-format
     {\titlerule*{.}\contentspage} % filler-page-format
 
@@ -28,4 +28,10 @@
     {\thecontentslabel :~ } % numbered-entry-format
     {} % numberless-entry-format
     {\titlerule*{.}\contentspage} % filler-page-format
+
+  \newcommand\tocchapapp{\tocchapterabbreviationname}
+  \g@addto@macro\appendix{%
+    \addtocontents{toc}{\protect\renewcommand{\protect\@chapapp}{\appendixname}}%
+    \addtocontents{toc}{\protect\renewcommand{\protect\tocchapapp}{\appendixname}}%
+  }
 }


### PR DESCRIPTION
As discussed in #305, this PR fixes the problem where Appendices show up as normal chapters in the table of contents.

It does this by renewing commands in the toc context when appendices start.
To stay compatible with the current abbreviation, I have added a new command, instead of just using `\chaptertitlename\` (as we now do in the footer).