### PR TITLE
make the d8 examples actually have 8 entries

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -310,6 +310,7 @@ They also accept an optional color argument to set the color for a single instan
   2  & Red feather \\
   3  & Human tooth \\
   4  & Vial of green liquid \\
+  5  & Loaded dice \\
   6  & Tasty biscuit \\
   7  & Broken axe handle \\
   8  & Tarnished silver locket \\
@@ -322,6 +323,7 @@ They also accept an optional color argument to set the color for a single instan
   2  & Red feather \\
   3  & Human tooth \\
   4  & Vial of green liquid \\
+  5  & Loaded dice \\
   6  & Tasty biscuit \\
   7  & Broken axe handle \\
   8  & Tarnished silver locket \\


### PR DESCRIPTION
In the `DndTable` `d8` examples, nr 5 was missing