### PR TITLE
use \dname variable instead of hardcoded d

### DIFF
--- a/lib/dndutility.sty
+++ b/lib/dndutility.sty
@@ -34,7 +34,7 @@
               \fp_eval:n { floor ( \l__dice_number_tl * ( \l__dice_sides_tl + 1 ) / 2 )\l__dice_mod_sign_tl \l__dice_mod_tl }~
 
               (
-                \l__dice_number_tl d \l__dice_sides_tl
+                \l__dice_number_tl \dname \l__dice_sides_tl
 
                 \str_case_e:nn { \l__dice_mod_sign_tl }
                   {


### PR DESCRIPTION
In German translations, dice rolls are written like `3W10+3` ( `W` instead of `d` ). I saw that there was a variable defined for this in `ngerman.sty`:

```latex
\renewcommand\dname{W}
```

but apparently it was not used when outputting dice rolls. 
