### PR TITLE
Add proficiency-bonus to \DndMonsterDetails (#319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* Added optional `proficiency-bonus` item to `\DnDMonsterDetails` that will be displayed next to the monster or NPC's challenge rating, as is the style in Candlekeep Mysteries and dndbeyond.
+
 ### Changed
 
 ## [0.8.0] - 2020-04-21

--- a/example.tex
+++ b/example.tex
@@ -179,6 +179,7 @@ The |DndTable| colors the even rows and is set to the width of a line by default
         senses = {darkvision 60 ft., passive Perception 10},
         languages = {Common, Goblin, Undercommon},
         challenge = 1,
+        proficiency-bonus = +2,
       ]
     % Traits
     \DndMonsterAction{Innate Spellcasting}

--- a/example.tex
+++ b/example.tex
@@ -179,7 +179,7 @@ The |DndTable| colors the even rows and is set to the width of a line by default
         senses = {darkvision 60 ft., passive Perception 10},
         languages = {Common, Goblin, Undercommon},
         challenge = 1,
-        proficiency-bonus = +2,
+        proficiency-bonus, % = +2
       ]
     % Traits
     \DndMonsterAction{Innate Spellcasting}

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -268,6 +268,9 @@
   challenge .tl_set:N         = \l__challenge_tl,
   challenge .initial:n        = 1,
   challenge .value_required:n = true,
+  proficiency-bonus .tl_set:N = \l__proficiency_tl,
+  proficiency-bonus .value_required:n = true,
+  proficiencybonus .meta:n    = { proficiency-bonus = {#1} },
 }
 
 \cs_new_protected_nopar:Npn \__dnd_monster_details:
@@ -282,6 +285,11 @@
       \item [\sensesname]    \l__senses_tl
       \item [\languagesname] \l__languages_tl
       \item [\challengename] \__dnd_cr_xp:N {\l__challenge_tl}
+      \tl_if_empty:NF {\l__proficiency_tl}
+        {
+          {\enit@svlabel{\enit@format{\pbonname}}}
+          \hskip \labelsep \l__proficiency_tl
+        }
     \end {__dnd_monster_attributes}
 }
 

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -239,6 +239,53 @@
       { #1 }
 }
 
+%% Monster CR/PB helper
+% \l_tmpa_tl - CR
+% \l_tmpb_tl - PB
+\cs_new_protected_nopar:Npn \__dnd_cr_pb:N #1
+  {
+    \tl_set:Nn \l_tmpa_tl {#1}
+    \str_case_e:nnTF {#1}
+      {
+        {0}   { \tl_set:Nn \l_tmpb_tl {+2} }
+        {1/8} { \tl_set:Nn \l_tmpb_tl {+2} }
+        {1/4} { \tl_set:Nn \l_tmpb_tl {+2} }
+        {1/2} { \tl_set:Nn \l_tmpb_tl {+2} }
+        {1}   { \tl_set:Nn \l_tmpb_tl {+2} }
+        {2}   { \tl_set:Nn \l_tmpb_tl {+2} }
+        {3}   { \tl_set:Nn \l_tmpb_tl {+2} }
+        {4}   { \tl_set:Nn \l_tmpb_tl {+2} }
+        {5}   { \tl_set:Nn \l_tmpb_tl {+3} }
+        {6}   { \tl_set:Nn \l_tmpb_tl {+3} }
+        {7}   { \tl_set:Nn \l_tmpb_tl {+3} }
+        {8}   { \tl_set:Nn \l_tmpb_tl {+3} }
+        {9}   { \tl_set:Nn \l_tmpb_tl {+4} }
+        {10}  { \tl_set:Nn \l_tmpb_tl {+4} }
+        {11}  { \tl_set:Nn \l_tmpb_tl {+4} }
+        {12}  { \tl_set:Nn \l_tmpb_tl {+4} }
+        {13}  { \tl_set:Nn \l_tmpb_tl {+5} }
+        {14}  { \tl_set:Nn \l_tmpb_tl {+5} }
+        {15}  { \tl_set:Nn \l_tmpb_tl {+5} }
+        {16}  { \tl_set:Nn \l_tmpb_tl {+5} }
+        {17}  { \tl_set:Nn \l_tmpb_tl {+6} }
+        {18}  { \tl_set:Nn \l_tmpb_tl {+6} }
+        {19}  { \tl_set:Nn \l_tmpb_tl {+6} }
+        {20}  { \tl_set:Nn \l_tmpb_tl {+6} }
+        {21}  { \tl_set:Nn \l_tmpb_tl {+7} }
+        {22}  { \tl_set:Nn \l_tmpb_tl {+7} }
+        {23}  { \tl_set:Nn \l_tmpb_tl {+7} }
+        {24}  { \tl_set:Nn \l_tmpb_tl {+7} }
+        {25}  { \tl_set:Nn \l_tmpb_tl {+8} }
+        {26}  { \tl_set:Nn \l_tmpb_tl {+8} }
+        {27}  { \tl_set:Nn \l_tmpb_tl {+8} }
+        {28}  { \tl_set:Nn \l_tmpb_tl {+8} }
+        {29}  { \tl_set:Nn \l_tmpb_tl {+9} }
+        {30}  { \tl_set:Nn \l_tmpb_tl {+9} }
+      }
+      { \numprint {\l_tmpb_tl} }
+      { #1 }
+  }
+
 %% Monster details
 \keys_define:nn { dnd / monster / details }
 {
@@ -269,7 +316,8 @@
   challenge .initial:n        = 1,
   challenge .value_required:n = true,
   proficiency-bonus .tl_set:N = \l__proficiency_tl,
-  proficiency-bonus .value_required:n = true,
+  proficiency-bonus .value_required:n = false,
+  proficiency-bonus .default:n = *,
   proficiencybonus .meta:n    = { proficiency-bonus = {#1} },
 }
 
@@ -288,7 +336,10 @@
       \tl_if_empty:NF {\l__proficiency_tl}
         {
           {\enit@svlabel{\enit@format{\pbonname}}}
-          \hskip \labelsep \l__proficiency_tl
+          \hskip \labelsep
+          \str_if_eq:VnTF \l__proficiency_tl *
+            {\__dnd_cr_pb:N {\l__challenge_tl}}
+            {\l__proficiency_tl}
         }
     \end {__dnd_monster_attributes}
 }

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -282,7 +282,7 @@
         {29}  { \tl_set:Nn \l_tmpb_tl {+9} }
         {30}  { \tl_set:Nn \l_tmpb_tl {+9} }
       }
-      { \numprint {\l_tmpb_tl} }
+      { \l_tmpb_tl }
       { #1 }
   }
 

--- a/lib/dndstrings.sty
+++ b/lib/dndstrings.sty
@@ -49,6 +49,7 @@
 \newcommand\defaultsensesname{passive~Perception~10}
 \newcommand\languagesname{Languages}
 \newcommand\challengename{Challenge}
+\newcommand\pbonname{Proficiency~Bonus}
 \newcommand\xpname{XP}
 
 % Attacks


### PR DESCRIPTION
Adds a `proficiency-bonus` detail that will be displayed next to the
monster or NPC's challenge rating, as is the style in Candlekeep Mysteries
and dndbeyond.