### PR TITLE
dndfonts.sty: Fix compilation with xelatex and lualatex

### DIFF
--- a/lib/dndfonts.sty
+++ b/lib/dndfonts.sty
@@ -11,7 +11,11 @@
   {
     \RequirePackage{bookman}
     \RequirePackage[type1]{gillius2}
-    \RequirePackage[notext,nomath,nott]{kpfonts}
+    \ifpdftex
+      \RequirePackage[notext,nomath,nott]{kpfonts}
+    \else
+      \RequirePackage[notext,nomath,nott]{kpfonts-otf}
+    \fi
     \RequirePackage[T1]{fontenc}
     \renewcommand{\sfdefault}{jkpss}
   }


### PR DESCRIPTION
dndfonts.sty includes kpfonts, which is compatible with pdflatex, but not with xelatex and lualatex. While the kpfonts package defaults to including kpfonts-otf when it detects xelatex or lualatex, it doesn't pass options to kpfonts-otf, which makes lualatex and xelatex complain about unrecognised options used in dndfonts.sty (i.e., notext, nomath, nott), and change almost all fonts in the style.

This fix tests for pdflatex in lib/dndfonts.sty, and else loads kpfonts-otf directly, correctly passing the necessary options.