### PR TITLE
Fix translations (abbreviations) in ngerman

### DIFF
--- a/lib/languages/ngerman.sty
+++ b/lib/languages/ngerman.sty
@@ -62,7 +62,7 @@
     \renewcommand\spellcomponentsname{Komponenten}
     \renewcommand\spelldurationname{Wirkungsdauer}
     % Miscellaneous
-%    \renewcommand\pageabbreviationname{pg.}
+    \renewcommand\pageabbreviationname{S.}
     \renewcommand\dname{W}
-%    \newcommand\tocchapterabbreviationname{Ch.}
+    \renewcommand\tocchapterabbreviationname{Kap.}
   }


### PR DESCRIPTION
Noticed the abbreviation of chapter in the toc was still in english, so I fixed it.
Also fixed the page abbreviation.