### PR TITLE
Fix monster attacks are always melee and ranged

### DIFF
--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -532,7 +532,7 @@
     distance .choice:,
     distance .choices:nn =
       { both, melee, ranged }
-      { \tl_set:Nn \l__dnd_attack_distance_tl {\l_keys_choice_tl} },
+      { \tl_set:Nn \l__dnd_attack_distance_tl { #1 } },
     distance .initial:n  = both,
     type .choice:,
     type / weapon .code:n = { \tl_set:Nn \l__dnd_attack_type_tl {\weaponname} },

--- a/lib/dndsections.sty
+++ b/lib/dndsections.sty
@@ -169,7 +169,7 @@
     area-num-depth .choice:,
     area-num-depth .choices:nn =
       { 1, 2, 3, 4 }
-      { \tl_set:Nn \l__dnd_area_num_depth_tl {\l_keys_choice_tl} },
+      { \tl_set:Nn \l__dnd_area_num_depth_tl {#1} },
     area-num-depth .initial:n  = 2, % subsection
   }
 


### PR DESCRIPTION
This PR addresses the issue that all attacking items listed in a monster's block is always shown as `Melee and Ranged weapon attack`, as posted in #377, and also a similar potential problem causing `\DndArea` captions to disappear. 

This issue seems to be caused by a wrong order of macro expansion, and can also be fixed as
```diff
-      { \tl_set:Nn \l__dnd_attack_distance_tl {\l_keys_choice_tl} },
+      { \tl_set:NV \l__dnd_attack_distance_tl {\l_keys_choice_tl} },
```
However as the LaTeX3 team are deprecating `\l_keys_choice_tl` (see [here](https://github.com/latex3/latex3/commit/685812157f37a7866101ccba2f9d394c0b4cc275)), this PR uses a simpler solution.
