### PR TITLE
Bug fix: DndReadAloud and DndSidebar fail when the optional argument …

### DIFF
--- a/lib/dndcomment.sty
+++ b/lib/dndcomment.sty
@@ -59,10 +59,9 @@
 \NewDocumentEnvironment {DndComment} { o m }
   {
     \group_begin:
-    \keys_set_known:nnN { dnd / comment } {#1} \l_tmpa_tl
-
-    \str_if_eq:VnT \l_tmpa_tl { -NoValue- }
-      { \tl_set_eq:NN \l_tmpa_tl \c_empty_tl }
+    \tl_clear:N \l_tmpa_tl
+    \tl_if_novalue:nF {#1}
+    { \keys_set_known:nnN { dnd / comment } {#1} \l_tmpa_tl }
 
     \__dnd_start_comment:nV
       {
@@ -70,7 +69,7 @@
           colbacktitle = \l__dnd_comment_color_tl,
           title        = {#2},
       }
-      { \l_tmpa_tl }
+      \l_tmpa_tl
   }
   {
     \end {__dnd_comment}

--- a/lib/dndreadaloud.sty
+++ b/lib/dndreadaloud.sty
@@ -61,20 +61,17 @@
 % The DndReadAloud environment
 % #1 - keys. We handle the custom color key before passing other keys on
 \NewDocumentEnvironment {DndReadAloud} {o}
-  {
-    \group_begin:
-    \keys_set_known:nnN { dnd / read_aloud } {#1} \l_tmpa_tl
+	{
+      		\group_begin:
+      		\tl_clear:N \l_tmpa_tl
+      		\tl_if_novalue:nF {#1}
+        		{ \keys_set_known:nnN { dnd / read_aloud } {#1} \l_tmpa_tl }
 
-    \str_if_eq:VnT \l_tmpa_tl { -NoValue- }
-      { \tl_set_eq:NN \l_tmpa_tl \c_empty_tl }
-
-    \__dnd_start_read_aloud:nV
-      {
-          colback = \l__dnd_read_aloud_color_tl,
-      }
-      {\l_tmpa_tl}
-  }
-  {
+      		\__dnd_start_read_aloud:nV
+        		{ colback = \l__dnd_read_aloud_color_tl, }
+        	\l_tmpa_tl
+    	}
+{
     \end {__dnd_read_aloud}
     \group_end:
   }

--- a/lib/dndsidebar.sty
+++ b/lib/dndsidebar.sty
@@ -66,21 +66,22 @@
 % #1 - keys. We handle the custom color key before passing other keys on
 % #2 - title.
 \NewDocumentEnvironment {DndSidebar} { o m }
-  {
-    \group_begin:
-    \keys_set_known:nnN { dnd / sidebar } {#1} \l_tmpa_tl
+    {
+      \group_begin:
+      \tl_clear:N \l_tmpa_tl
+      \tl_if_novalue:nF {#1}
+        { \keys_set_known:nnN { dnd / sidebar } {#1} \l_tmpa_tl }
 
-    \str_if_eq:VnT \l_tmpa_tl { -NoValue- }
-      { \tl_set_eq:NN \l_tmpa_tl \c_empty_tl }
-
-    \__dnd_start_sidebar:nV
-      {
+      \__dnd_start_sidebar:nV
+        {
           colback      = \l__dnd_sidebar_color_tl,
           colbacktitle = \l__dnd_sidebar_color_tl,
           title        = {#2},
-      }
-      {\l_tmpa_tl}
-  }
+        }
+        \l_tmpa_tl
+    }
+
+
   {
     \end {__dnd_sidebar}
     \group_end:


### PR DESCRIPTION
With newer LaTeX3 / TeX Live 2026, omitted optional arguments can propagate `\NoValue` into
  `tcolorbox`, causing errors like:

  `Package pgfkeys Error: I do not know the key '/tcb/\NoValue'`

  This patch replaces the legacy `-NoValue-` string handling with `\tl_if_novalue:nF` in:
  - `DndReadAloud`
  - `DndSidebar`
  - `DndComment`

  This preserves the documented syntax, so these forms work again without requiring empty brackets:
  - `\begin{DndReadAloud}`
  - `\begin{DndSidebar}{Title}`
  - `\begin{DndComment}{Title}`
